### PR TITLE
Add PolySharpUsePublicAccessibilityForGeneratedTypes option

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -63,3 +63,29 @@ jobs:
         name: nuget_preview
         path: artifacts\*.nupkg
         if-no-files-found: error
+
+  # Download the NuGet packages generated in the previous job and use them
+  # to build and run the sample project referencing them. This is used as
+  # a test to ensure the NuGet packages work in a consuming project.
+  verify-packages:
+    if: success()
+    needs: [build-packages]
+    runs-on: windows-2022
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v3
+    - name: Setup .NET 6 SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Create local NuGet feed
+      run: mkdir artifacts
+      shell: cmd
+    - name: Download package artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: nuget_preview
+        path: artifacts
+    - name: Build PolySharp.NuGet
+      run: dotnet build tests\PolySharp.NuGet\PolySharp.NuGet.csproj -c Release
+      shell: cmd

--- a/PolySharp.sln
+++ b/PolySharp.sln
@@ -10,6 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{8D
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{D65D0307-1D0F-499D-945B-E33E71F251A4}"
+	ProjectSection(SolutionItems) = preProject
+		tests\PolySharp.NuGet\PolySharp.NuGet.csproj = tests\PolySharp.NuGet\PolySharp.NuGet.csproj
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolySharp.Tests", "tests\PolySharp.Tests\PolySharp.Tests.csproj", "{41EC2F2E-797F-486A-8E2E-1788C7CF0DF3}"
 EndProject

--- a/PolySharp.sln
+++ b/PolySharp.sln
@@ -11,7 +11,24 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Projects", "Projects", "{8D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{D65D0307-1D0F-499D-945B-E33E71F251A4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PolySharp.Tests", "tests\PolySharp.Tests\PolySharp.Tests.csproj", "{41EC2F2E-797F-486A-8E2E-1788C7CF0DF3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolySharp.Tests", "tests\PolySharp.Tests\PolySharp.Tests.csproj", "{41EC2F2E-797F-486A-8E2E-1788C7CF0DF3}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_SolutionItems", "_SolutionItems", "{C0C25293-DF18-48E5-BCE9-499CB6D66BB6}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D78D3FFF-DB82-41B3-951F-40C7ED8F8F07}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +50,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{41EC2F2E-797F-486A-8E2E-1788C7CF0DF3} = {D65D0307-1D0F-499D-945B-E33E71F251A4}
+		{D78D3FFF-DB82-41B3-951F-40C7ED8F8F07} = {C0C25293-DF18-48E5-BCE9-499CB6D66BB6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F946EBAA-2D9B-4599-B4A2-7ECD81E0DF61}

--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@
   - `[InterpolatedStringHandler]`
   - `[InterpolatedStringHandlerArgument]`
 - `[CallerArgumentExpression]` (see [docs](https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-10.0/caller-argument-expression))
+
+# Options ⚙️
+
+**PolySharp**'s generation can be configured through some MSBuild properties to set in consuming projects.
+
+The following properties are available:
+- `PolySharpUsePublicAccessibilityForGeneratedTypes`: changes the accessibility of generated types from `internal` to `public`

--- a/src/PolySharp.SourceGenerators/Extensions/AnalyzerConfigOptionsProviderExtensions.cs
+++ b/src/PolySharp.SourceGenerators/Extensions/AnalyzerConfigOptionsProviderExtensions.cs
@@ -21,8 +21,9 @@ internal static class AnalyzerConfigOptionsProviderExtensions
     /// <remarks>The return value is equivalent to a <c>'$(PropertyName)' == 'true'</c> check.</remarks>
     public static bool GetBoolMSBuildProperty(this AnalyzerConfigOptionsProvider options, string propertyName)
     {
+        // MSBuild property that are visible to the compiler are available here with the "build_property." prefix
         return
-            options.GlobalOptions.TryGetValue(propertyName, out string? propertyValue) &&
+            options.GlobalOptions.TryGetValue($"build_property.{propertyName}", out string? propertyValue) &&
             string.Equals(propertyValue, bool.TrueString, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/PolySharp.SourceGenerators/Extensions/AnalyzerConfigOptionsProviderExtensions.cs
+++ b/src/PolySharp.SourceGenerators/Extensions/AnalyzerConfigOptionsProviderExtensions.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace PolySharp.SourceGenerators.Extensions;
+
+/// <summary>
+/// Extension methods for the <see cref="AnalyzerConfigOptionsProvider"/> type.
+/// </summary>
+internal static class AnalyzerConfigOptionsProviderExtensions
+{
+    /// <summary>
+    /// Gets the value of a <see cref="bool"/> MSBuild property.
+    /// </summary>
+    /// <param name="options">The input <see cref="AnalyzerConfigOptionsProvider"/> instance.</param>
+    /// <param name="propertyName">The MSBuild property name.</param>
+    /// <returns>The value of the specified MSBuild property.</returns>
+    /// <remarks>The return value is equivalent to a <c>'$(PropertyName)' == 'true'</c> check.</remarks>
+    public static bool GetBoolMSBuildProperty(this AnalyzerConfigOptionsProvider options, string propertyName)
+    {
+        return
+            options.GlobalOptions.TryGetValue(propertyName, out string? propertyValue) &&
+            string.Equals(propertyValue, bool.TrueString, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/PolySharp.SourceGenerators/PolySharp.targets
+++ b/src/PolySharp.SourceGenerators/PolySharp.targets
@@ -13,10 +13,12 @@
           AfterTargets="ResolvePackageDependenciesForBuild;ResolveNuGetPackageAssets"
           DependsOnTargets="_PolySharpGatherAnalyzers">
 
-    <!-- Use the CSharpCoreTargetsPath property to find the version of the compiler we are using. This is the same mechanism
-         MSBuild uses to find the compiler. We could check the assembly version for any compiler assembly (since they all have
-         the same version) but Microsoft.Build.Tasks.CodeAnalysis.dll is where MSBuild loads the compiler tasks from so if
-         someone is getting creative with msbuild tasks/targets this is the "most correct" assembly to check. -->
+    <!--
+      Use the CSharpCoreTargetsPath property to find the version of the compiler we are using. This is the same mechanism
+      MSBuild uses to find the compiler. We could check the assembly version for any compiler assembly (since they all have
+      the same version) but Microsoft.Build.Tasks.CodeAnalysis.dll is where MSBuild loads the compiler tasks from so if
+      someone is getting creative with msbuild tasks/targets this is the "most correct" assembly to check.
+    -->
     <GetAssemblyIdentity AssemblyFiles="$([System.IO.Path]::Combine(`$([System.IO.Path]::GetDirectoryName($(CSharpCoreTargetsPath)))`,`Microsoft.Build.Tasks.CodeAnalysis.dll`))">
       <Output TaskParameter="Assemblies" ItemName="PolySharpCurrentCompilerAssemblyIdentity"/>
     </GetAssemblyIdentity>
@@ -35,9 +37,16 @@
       <Analyzer Remove="@(_PolySharpAnalyzer)"/>
     </ItemGroup>
 
-    <!-- If the source generators are disabled, also emit an error. This would've been produced by MSBuild itself as well, but
-         emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
-         disabled, and that PolySharp will not work at all unless a more up to date IDE or compiler version are used. -->
+    <!-- Mark the PolySharpUsePublicAccessibilityForGeneratedTypes property as visible for the compiler, so the analyzer can see it -->
+    <ItemGroup>
+      <CompilerVisibleProperty Include="PolySharpUsePublicAccessibilityForGeneratedTypes"/>
+    </ItemGroup>
+
+    <!--
+      If the source generators are disabled, also emit an error. This would've been produced by MSBuild itself as well, but
+      emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
+      disabled, and that PolySharp will not work at all unless a more up to date IDE or compiler version are used.
+    -->
     <Error Condition ="'$(PolySharpCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The PolySharp source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. PolySharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.3 or greater) or .NET SDK version (.NET 6 SDK or greater)."/>  
   </Target>
   

--- a/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
+++ b/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
@@ -60,7 +60,7 @@ internal sealed class PolyfillsGenerator : IIncrementalGenerator
                     using Stream stream = typeof(PolyfillsGenerator).Assembly.GetManifestResourceStream(resourceName);
 
                     // If public accessibility has been requested, we need to update the loaded source files
-                    if (!generationOptions.UsePublicAccessibilityForGeneratedTypes)
+                    if (generationOptions.UsePublicAccessibilityForGeneratedTypes)
                     {
                         using StreamReader reader = new(stream);
 

--- a/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
+++ b/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
@@ -16,11 +16,17 @@ internal sealed class PolyfillsGenerator : IIncrementalGenerator
     /// <summary>
     /// The dictionary of cached sources to produce.
     /// </summary>
-    private readonly ConcurrentDictionary<string, SourceText> manifestSources = new();
+    private readonly ConcurrentDictionary<(string FullyQualifiedMetadataName, bool UsePublicAccessibility), SourceText> manifestSources = new();
 
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
+        // Check whether the generated types should use public accessibility. Consuming projects can define the
+        // $(PolySharpUsePublicAccessibilityForGeneratedTypes) MSBuild property to configure this however they need.
+        IncrementalValueProvider<bool> usePublicAccessibilityForGeneratedTypes =
+            context.AnalyzerConfigOptionsProvider
+            .Select((options, _) => options.GetBoolMSBuildProperty("PolySharpUsePublicAccessibilityForGeneratedTypes"));
+
         // Enumerate each embedded resource: each will map to a type that can be polyfilled. Types are
         // polyfilled one by one if not available, to avoid errors if users had some manual polyfills already.
         foreach (string resourceName in typeof(PolyfillsGenerator).Assembly.GetManifestResourceNames())
@@ -35,23 +41,46 @@ internal sealed class PolyfillsGenerator : IIncrementalGenerator
                 context.CompilationProvider
                 .Select((compilation, _) => compilation.HasAccessibleTypeWithMetadataName(fullyQualifiedMetadataName));
 
+            // Prepare the generation options for the current polyfill
+            IncrementalValueProvider<(bool IsTypeAccessible, bool UsePublicAccessibilityForGeneratedTypes)> generationOptions =
+                isTypeAccessible.Combine(usePublicAccessibilityForGeneratedTypes);
+
             // Generate source for the current type depending on current accessibility
-            context.RegisterSourceOutput(isTypeAccessible, (context, isTypeAccessible) =>
+            context.RegisterSourceOutput(generationOptions, (context, generationOptions) =>
             {
                 // The type is already accessible, so nothing more to do
-                if (isTypeAccessible)
+                if (generationOptions.IsTypeAccessible)
                 {
                     return;
                 }
 
                 // Get the source text from the cache, or load it if needed
-                if (!this.manifestSources.TryGetValue(fullyQualifiedMetadataName, out SourceText? sourceText))
+                if (!this.manifestSources.TryGetValue((fullyQualifiedMetadataName, generationOptions.UsePublicAccessibilityForGeneratedTypes), out SourceText? sourceText))
                 {
                     using Stream stream = typeof(PolyfillsGenerator).Assembly.GetManifestResourceStream(resourceName);
 
-                    sourceText = SourceText.From(stream, Encoding.UTF8, canBeEmbedded: true);
+                    // If public accessibility has been requested, we need to update the loaded source files
+                    if (!generationOptions.UsePublicAccessibilityForGeneratedTypes)
+                    {
+                        using StreamReader reader = new(stream);
 
-                    _ = this.manifestSources.TryAdd(fullyQualifiedMetadataName, sourceText);
+                        // Read the source and replace all internal keywords with public. Use a space before and after the identifier
+                        // to avoid potential false positives. This could also be done by loading the source tree and using a syntax
+                        // rewriter, or just by retrieving the type declaration syntax and updating the modifier tokens, but since the
+                        // change is so minimal, it can very well just be done this way to keep things simple, that's fine in this case.
+                        string originalSource = reader.ReadToEnd();
+                        string adjustedSource = originalSource.Replace(" internal ", " public ");
+
+                        sourceText = SourceText.From(adjustedSource, Encoding.UTF8);
+                    }
+                    else
+                    {
+                        // If the default accessibility is used, we can load the source directly
+                        sourceText = SourceText.From(stream, Encoding.UTF8, canBeEmbedded: true);
+                    }
+
+                    // Cache the generated source (if we raced against another thread, just discard the result)
+                    _ = this.manifestSources.TryAdd((fullyQualifiedMetadataName, generationOptions.UsePublicAccessibilityForGeneratedTypes), sourceText);
                 }
 
                 // Finally generate the source text

--- a/tests/PolySharp.NuGet/PolySharp.NuGet.csproj
+++ b/tests/PolySharp.NuGet/PolySharp.NuGet.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RestoreSources>
+      https://api.nuget.org/v3/index.json;
+      ..\..\artifacts;
+    </RestoreSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="PolySharp" Version="$(PackageVersion)" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\PolySharp.Tests\LanguageFeatures.cs" />
+  </ItemGroup>
+
+</Project>

--- a/tests/PolySharp.Tests/PolySharp.Tests.csproj
+++ b/tests/PolySharp.Tests/PolySharp.Tests.csproj
@@ -2,7 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <PolySharpUsePublicAccessibilityForGeneratedTypes>true</PolySharpUsePublicAccessibilityForGeneratedTypes>
   </PropertyGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="PolySharpUsePublicAccessibilityForGeneratedTypes"/>
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.5" />


### PR DESCRIPTION
### Description

This PR adds the `PolySharpUsePublicAccessibilityForGeneratedTypes` option to generate polyfills as public types.