### PR TITLE
Use global:: and fully qualified type names in generated files

### DIFF
--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute.cs
@@ -14,14 +14,16 @@ namespace System.Diagnostics.CodeAnalysis
     /// This can be used to inform tooling of a dependency that is otherwise not evident purely from
     /// metadata and IL, for example a member relied on via reflection.
     /// </remarks>
-    [AttributeUsage(
-        AttributeTargets.Constructor | AttributeTargets.Field | AttributeTargets.Method,
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Method,
         AllowMultiple = true, Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class DynamicDependencyAttribute : Attribute
+    internal sealed class DynamicDependencyAttribute : global::System.Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// Initializes a new instance of the <see cref="global::System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute"/> class
         /// with the specified signature of a member on the same type as the consumer.
         /// </summary>
         /// <param name="memberSignature">The signature of the member depended on.</param>
@@ -31,12 +33,12 @@ namespace System.Diagnostics.CodeAnalysis
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
-        /// with the specified signature of a member on a <see cref="System.Type"/>.
+        /// Initializes a new instance of the <see cref="global::System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute"/> class
+        /// with the specified signature of a member on a <see cref="global::System.Type"/>.
         /// </summary>
         /// <param name="memberSignature">The signature of the member depended on.</param>
-        /// <param name="type">The <see cref="System.Type"/> containing <paramref name="memberSignature"/>.</param>
-        public DynamicDependencyAttribute(string memberSignature, Type type)
+        /// <param name="type">The <see cref="global::System.Type"/> containing <paramref name="memberSignature"/>.</param>
+        public DynamicDependencyAttribute(string memberSignature, global::System.Type type)
         {
             MemberSignature = memberSignature;
             Type = type;
@@ -57,25 +59,25 @@ namespace System.Diagnostics.CodeAnalysis
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
-        /// with the specified types of members on a <see cref="System.Type"/>.
+        /// Initializes a new instance of the <see cref="global::System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute"/> class
+        /// with the specified types of members on a <see cref="global::System.Type"/>.
         /// </summary>
         /// <param name="memberTypes">The types of members depended on.</param>
-        /// <param name="type">The <see cref="System.Type"/> containing the specified members.</param>
-        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, Type type)
+        /// <param name="type">The <see cref="global::System.Type"/> containing the specified members.</param>
+        public DynamicDependencyAttribute(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes memberTypes, global::System.Type type)
         {
             MemberTypes = memberTypes;
             Type = type;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// Initializes a new instance of the <see cref="global::System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute"/> class
         /// with the specified types of members on a type in an assembly.
         /// </summary>
         /// <param name="memberTypes">The types of members depended on.</param>
         /// <param name="typeName">The full name of the type containing the specified members.</param>
         /// <param name="assemblyName">The assembly name of the type containing the specified members.</param>
-        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, string typeName, string assemblyName)
+        public DynamicDependencyAttribute(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes memberTypes, string typeName, string assemblyName)
         {
             MemberTypes = memberTypes;
             TypeName = typeName;
@@ -87,28 +89,28 @@ namespace System.Diagnostics.CodeAnalysis
         /// </summary>
         /// <remarks>
         /// Either <see cref="MemberSignature"/> must be a valid string or <see cref="MemberTypes"/>
-        /// must not equal <see cref="DynamicallyAccessedMemberTypes.None"/>, but not both.
+        /// must not equal <see cref="global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None"/>, but not both.
         /// </remarks>
         public string? MemberSignature { get; }
 
         /// <summary>
-        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// Gets the <see cref="global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes"/> which specifies the type
         /// of members depended on.
         /// </summary>
         /// <remarks>
         /// Either <see cref="MemberSignature"/> must be a valid string or <see cref="MemberTypes"/>
-        /// must not equal <see cref="DynamicallyAccessedMemberTypes.None"/>, but not both.
+        /// must not equal <see cref="global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None"/>, but not both.
         /// </remarks>
-        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+        public global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberTypes { get; }
 
         /// <summary>
-        /// Gets the <see cref="System.Type"/> containing the specified member.
+        /// Gets the <see cref="global::System.Type"/> containing the specified member.
         /// </summary>
         /// <remarks>
         /// If neither <see cref="Type"/> nor <see cref="TypeName"/> are specified,
         /// the type of the consumer is assumed.
         /// </remarks>
-        public Type? Type { get; }
+        public global::System.Type? Type { get; }
 
         /// <summary>
         /// Gets the full name of the type containing the specified member.

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.cs
@@ -10,10 +10,10 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Specifies the types of members that are dynamically accessed.
     ///
-    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// This enumeration has a <see cref="global::System.FlagsAttribute"/> attribute that allows a
     /// bitwise combination of its member values.
     /// </summary>
-    [Flags]
+    [global::System.Flags]
     internal enum DynamicallyAccessedMemberTypes
     {
         /// <summary>
@@ -29,7 +29,7 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>
         /// Specifies all public constructors.
         /// </summary>
-        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+        PublicConstructors = 0x0002 | global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicParameterlessConstructor,
 
         /// <summary>
         /// Specifies all non-public constructors.
@@ -94,6 +94,6 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>
         /// Specifies all members.
         /// </summary>
-        All = ~None
+        All = ~global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.None
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute.cs
@@ -8,20 +8,20 @@
 namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>
-    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
-    /// for example through <see cref="System.Reflection"/>.
+    /// Indicates that certain members on a specified <see cref="global::System.Type"/> are accessed dynamically,
+    /// for example through <see cref="global::System.Reflection"/>.
     /// </summary>
     /// <remarks>
     /// This allows tools to understand which members are being accessed during the execution
     /// of a program.
     ///
-    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    /// This attribute is valid on members whose type is <see cref="global::System.Type"/> or <see cref="string"/>.
     ///
     /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
     /// that the string represents a fully qualified type name.
     ///
     /// When this attribute is applied to a class, interface, or struct, the members specified
-    /// can be accessed dynamically on <see cref="Type"/> instances returned from calling
+    /// can be accessed dynamically on <see cref="global::System.Type"/> instances returned from calling
     /// <see cref="object.GetType"/> on instances of that class, interface, or struct.
     ///
     /// If the attribute is applied to a method it's treated as a special case and it implies
@@ -29,28 +29,34 @@ namespace System.Diagnostics.CodeAnalysis
     /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
     /// will use it there).
     /// </remarks>
-    [AttributeUsage(
-        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
-        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method |
-        AttributeTargets.Class | AttributeTargets.Interface | AttributeTargets.Struct,
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.ReturnValue |
+        global::System.AttributeTargets.GenericParameter |
+        global::System.AttributeTargets.Parameter |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Interface |
+        global::System.AttributeTargets.Struct,
         Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class DynamicallyAccessedMembersAttribute : Attribute
+    internal sealed class DynamicallyAccessedMembersAttribute : global::System.Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// Initializes a new instance of the <see cref="global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute"/> class
         /// with the specified member types.
         /// </summary>
         /// <param name="memberTypes">The types of members dynamically accessed.</param>
-        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        public DynamicallyAccessedMembersAttribute(global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes memberTypes)
         {
             MemberTypes = memberTypes;
         }
 
         /// <summary>
-        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// Gets the <see cref="global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes"/> which specifies the type
         /// of members dynamically accessed.
         /// </summary>
-        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+        public global::System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes MemberTypes { get; }
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute.cs
@@ -9,18 +9,21 @@ namespace System.Diagnostics.CodeAnalysis
 {
     /// <summary>
     /// Indicates that the specified method requires dynamic access to code that is not referenced
-    /// statically, for example through <see cref="System.Reflection"/>.
+    /// statically, for example through <see cref="global::System.Reflection"/>.
     /// </summary>
     /// <remarks>
     /// This allows tools to understand which methods are unsafe to call when removing unreferenced
     /// code from an application.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class, Inherited = false)]
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Class, Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class RequiresUnreferencedCodeAttribute : Attribute
+    internal sealed class RequiresUnreferencedCodeAttribute : global::System.Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RequiresUnreferencedCodeAttribute"/> class
+        /// Initializes a new instance of the <see cref="global::System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute"/> class
         /// with the specified message.
         /// </summary>
         /// <param name="message">

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute.cs
@@ -12,16 +12,16 @@ namespace System.Diagnostics.CodeAnalysis
     /// single code artifact.
     /// </summary>
     /// <remarks>
-    /// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
-    /// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
-    /// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+    /// <see cref="global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute"/> is different than
+    /// <see cref="global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute"/> in that it doesn't have a
+    /// <see cref="global::System.Diagnostics.ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.All, Inherited = false, AllowMultiple = true)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class UnconditionalSuppressMessageAttribute : Attribute
+    internal sealed class UnconditionalSuppressMessageAttribute : global::System.Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+        /// Initializes a new instance of the <see cref="global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute"/>
         /// class, specifying the category of the tool and the identifier for an analysis rule.
         /// </summary>
         /// <param name="category">The category for the attribute.</param>
@@ -76,7 +76,7 @@ namespace System.Diagnostics.CodeAnalysis
         /// <remarks>
         /// The <see cref="MessageId "/> property is an optional argument that specifies additional
         /// exclusion where the literal metadata target is not sufficiently precise. For example,
-        /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+        /// the <see cref="global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
         /// and it may be desirable to suppress a violation against a statement in the method that will
         /// give a rule violation, but not against all statements in the method.
         /// </remarks>

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.StackTraceHiddenAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.StackTraceHiddenAttribute.cs
@@ -11,12 +11,17 @@ namespace System.Diagnostics
     /// Types and Methods attributed with StackTraceHidden will be omitted from the stack trace text shown in StackTrace.ToString()
     /// and Exception.StackTrace
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Struct, Inherited = false)]
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Struct,
+        Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class StackTraceHiddenAttribute : Attribute
+    internal sealed class StackTraceHiddenAttribute : global::System.Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="StackTraceHiddenAttribute"/> class.
+        /// Initializes a new instance of the <see cref="global::System.Diagnostics.StackTraceHiddenAttribute"/> class.
         /// </summary>
         public StackTraceHiddenAttribute() { }
     }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute.cs
@@ -18,8 +18,8 @@ namespace System.Runtime.InteropServices
     ///   * Must not be called from managed code.
     ///   * Must only have <see href="https://docs.microsoft.com/dotnet/framework/interop/blittable-and-non-blittable-types">blittable</see> arguments.
     /// </remarks>
-    [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
     internal sealed class UnmanagedCallersOnlyAttribute : Attribute
     {
         public UnmanagedCallersOnlyAttribute()

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute.cs
@@ -8,7 +8,7 @@
 namespace System.Runtime.InteropServices
 {
     /// <summary>
-    /// Any method marked with <see cref="System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute" /> can be directly called from
+    /// Any method marked with <see cref="global::System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute" /> can be directly called from
     /// native code. The function token can be loaded to a local variable using the <see href="https://docs.microsoft.com/dotnet/csharp/language-reference/operators/pointer-related-operators#address-of-operator-">address-of</see> operator
     /// in C# and passed as a callback to a native method.
     /// </summary>
@@ -18,9 +18,9 @@ namespace System.Runtime.InteropServices
     ///   * Must not be called from managed code.
     ///   * Must only have <see href="https://docs.microsoft.com/dotnet/framework/interop/blittable-and-non-blittable-types">blittable</see> arguments.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class UnmanagedCallersOnlyAttribute : Attribute
+    internal sealed class UnmanagedCallersOnlyAttribute : global::System.Attribute
     {
         public UnmanagedCallersOnlyAttribute()
         {
@@ -33,7 +33,7 @@ namespace System.Runtime.InteropServices
         /// Supplied types must be from the official "System.Runtime.CompilerServices" namespace and
         /// be of the form "CallConvXXX".
         /// </remarks>
-        public Type[]? CallConvs;
+        public global::System.Type[]? CallConvs;
 
         /// <summary>
         /// Optional. If omitted, no named export is emitted during compilation.

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.ObsoletedOSPlatformAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.ObsoletedOSPlatformAttribute.cs
@@ -13,20 +13,21 @@ namespace System.Runtime.Versioning
     /// <remarks>
     /// Primarily used by OS bindings to indicate APIs that should not be used anymore.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Assembly |
-                    AttributeTargets.Class |
-                    AttributeTargets.Constructor |
-                    AttributeTargets.Enum |
-                    AttributeTargets.Event |
-                    AttributeTargets.Field |
-                    AttributeTargets.Interface |
-                    AttributeTargets.Method |
-                    AttributeTargets.Module |
-                    AttributeTargets.Property |
-                    AttributeTargets.Struct,
-                    AllowMultiple = true, Inherited = false)]
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Assembly |
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Enum |
+        global::System.AttributeTargets.Event |
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Interface |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Module |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Struct,
+        AllowMultiple = true, Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class ObsoletedOSPlatformAttribute : Attribute // OSPlatformAttribute
+    internal sealed class ObsoletedOSPlatformAttribute : global::System.Attribute // OSPlatformAttribute
     {
         public ObsoletedOSPlatformAttribute(string platformName)
             // : base(platformName)

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.SupportedOSPlatformAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.SupportedOSPlatformAttribute.cs
@@ -12,25 +12,26 @@ namespace System.Runtime.Versioning
     /// applied to indicate support on multiple operating systems.
     /// </summary>
     /// <remarks>
-    /// Callers can apply a <see cref="System.Runtime.Versioning.SupportedOSPlatformAttribute " />
+    /// Callers can apply a <see cref="global::System.Runtime.Versioning.SupportedOSPlatformAttribute " />
     /// or use guards to prevent calls to APIs on unsupported operating systems.
     ///
     /// A given platform should only be specified once.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Assembly |
-                    AttributeTargets.Class |
-                    AttributeTargets.Constructor |
-                    AttributeTargets.Enum |
-                    AttributeTargets.Event |
-                    AttributeTargets.Field |
-                    AttributeTargets.Interface |
-                    AttributeTargets.Method |
-                    AttributeTargets.Module |
-                    AttributeTargets.Property |
-                    AttributeTargets.Struct,
-                    AllowMultiple = true, Inherited = false)]
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Assembly |
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Enum |
+        global::System.AttributeTargets.Event |
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Interface |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Module |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Struct,
+        AllowMultiple = true, Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class SupportedOSPlatformAttribute : Attribute // OSPlatformAttribute
+    internal sealed class SupportedOSPlatformAttribute : global::System.Attribute // OSPlatformAttribute
     {
         public SupportedOSPlatformAttribute(string platformName)
             // : base(platformName)

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.SupportedOSPlatformGuardAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.SupportedOSPlatformGuardAttribute.cs
@@ -12,17 +12,18 @@ namespace System.Runtime.Versioning
     /// Multiple attributes can be applied to indicate guard for multiple supported platforms.
     /// </summary>
     /// <remarks>
-    /// Callers can apply a <see cref="System.Runtime.Versioning.SupportedOSPlatformGuardAttribute " /> to a field, property or method
+    /// Callers can apply a <see cref="global::System.Runtime.Versioning.SupportedOSPlatformGuardAttribute " /> to a field, property or method
     /// and use that field, property or method in a conditional or assert statements in order to safely call platform specific APIs.
     ///
     /// The type of the field or property should be boolean, the method return type should be boolean in order to be used as platform guard.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Field |
-                    AttributeTargets.Method |
-                    AttributeTargets.Property,
-                    AllowMultiple = true, Inherited = false)]
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property,
+        AllowMultiple = true, Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class SupportedOSPlatformGuardAttribute : Attribute // OSPlatformAttribute
+    internal sealed class SupportedOSPlatformGuardAttribute : global::System.Attribute // OSPlatformAttribute
     {
         public SupportedOSPlatformGuardAttribute(string platformName)
             // : base(platformName)

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.TargetPlatformAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.TargetPlatformAttribute.cs
@@ -10,9 +10,9 @@ namespace System.Runtime.Versioning
     /// <summary>
     /// Records the platform that the project targeted.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class TargetPlatformAttribute : Attribute // OSPlatformAttribute
+    internal sealed class TargetPlatformAttribute : global::System.Attribute // OSPlatformAttribute
     {
         public TargetPlatformAttribute(string platformName)
             // : base(platformName)

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.UnsupportedOSPlatformAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.UnsupportedOSPlatformAttribute.cs
@@ -14,20 +14,21 @@ namespace System.Runtime.Versioning
     /// Primarily used by OS bindings to indicate APIs that are only available in
     /// earlier versions.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Assembly |
-                    AttributeTargets.Class |
-                    AttributeTargets.Constructor |
-                    AttributeTargets.Enum |
-                    AttributeTargets.Event |
-                    AttributeTargets.Field |
-                    AttributeTargets.Interface |
-                    AttributeTargets.Method |
-                    AttributeTargets.Module |
-                    AttributeTargets.Property |
-                    AttributeTargets.Struct,
-                    AllowMultiple = true, Inherited = false)]
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Assembly |
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Enum |
+        global::System.AttributeTargets.Event |
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Interface |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Module |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Struct,
+        AllowMultiple = true, Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class UnsupportedOSPlatformAttribute : Attribute // OSPlatformAttribute
+    internal sealed class UnsupportedOSPlatformAttribute : global::System.Attribute // OSPlatformAttribute
     {
         public UnsupportedOSPlatformAttribute(string platformName)
             // : base(platformName)

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute.cs
@@ -12,17 +12,18 @@ namespace System.Runtime.Versioning
     /// Multiple attributes can be applied to indicate guard for multiple unsupported platforms.
     /// </summary>
     /// <remarks>
-    /// Callers can apply a <see cref="System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute " /> to a field, property or method
+    /// Callers can apply a <see cref="global::System.Runtime.Versioning.UnsupportedOSPlatformGuardAttribute " /> to a field, property or method
     /// and use that  field, property or method in a conditional or assert statements as a guard to safely call APIs unsupported on those platforms.
     ///
     /// The type of the field or property should be boolean, the method return type should be boolean in order to be used as platform guard.
     /// </remarks>
-    [AttributeUsage(AttributeTargets.Field |
-                    AttributeTargets.Method |
-                    AttributeTargets.Property,
-                    AllowMultiple = true, Inherited = false)]
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property,
+        AllowMultiple = true, Inherited = false)]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
-    internal sealed class UnsupportedOSPlatformGuardAttribute : Attribute // OSPlatformAttribute
+    internal sealed class UnsupportedOSPlatformGuardAttribute : global::System.Attribute // OSPlatformAttribute
     {
         public UnsupportedOSPlatformGuardAttribute(string platformName)
             // : base(platformName)

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.AllowNullAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.AllowNullAttribute.cs
@@ -10,8 +10,12 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Specifies that null is allowed as an input even if the corresponding type disallows it.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-    internal sealed class AllowNullAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Parameter |
+        global::System.AttributeTargets.Property,
+        Inherited = false)]
+    internal sealed class AllowNullAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.DisallowNullAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.DisallowNullAttribute.cs
@@ -10,8 +10,12 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Specifies that null is disallowed as an input even if the corresponding type allows it.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
-    internal sealed class DisallowNullAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Parameter |
+        global::System.AttributeTargets.Property,
+        Inherited = false)]
+    internal sealed class DisallowNullAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute.cs
@@ -10,8 +10,8 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Applied to a method that will never return under any circumstance.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
-    internal sealed class DoesNotReturnAttribute : Attribute
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false)]
+    internal sealed class DoesNotReturnAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute.cs
@@ -10,8 +10,8 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Specifies that the method will not return if the associated Boolean parameter is passed the specified value.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    internal sealed class DoesNotReturnIfAttribute : Attribute
+    [global::System.AttributeUsage(global::System.AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class DoesNotReturnIfAttribute : global::System.Attribute
     {
         /// <summary>
         /// Initializes the attribute with the specified parameter value.

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.MaybeNullAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.MaybeNullAttribute.cs
@@ -10,8 +10,13 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Specifies that an output may be null even if the corresponding type disallows it.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-    internal sealed class MaybeNullAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Parameter |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.ReturnValue,
+        Inherited = false)]
+    internal sealed class MaybeNullAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.MaybeNullWhenAttribute.cs
@@ -10,8 +10,8 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    internal sealed class MaybeNullWhenAttribute : Attribute
+    [global::System.AttributeUsage(global::System.AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : global::System.Attribute
     {
         /// <summary>
         /// Initializes the attribute with the specified return value condition.

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.MemberNotNullAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.MemberNotNullAttribute.cs
@@ -10,8 +10,11 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Specifies that the method or property will ensure that the listed field and property members have not-null values.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
-    internal sealed class MemberNotNullAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property,
+        Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullAttribute : global::System.Attribute
     {
         /// <summary>
         /// Initializes the attribute with a field or property member.

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute.cs
@@ -11,8 +11,11 @@ namespace System.Diagnostics.CodeAnalysis
     /// Specifies that the method or property will ensure that the listed field and property
     /// members have not-null values when returning with the specified return value condition.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
-    internal sealed class MemberNotNullWhenAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property,
+        Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullWhenAttribute : global::System.Attribute
     {
         /// <summary>
         /// Initializes the attribute with the specified return value condition and a field or property member.

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.NotNullAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.NotNullAttribute.cs
@@ -11,8 +11,13 @@ namespace System.Diagnostics.CodeAnalysis
     /// Specifies that an output will not be null even if the corresponding type allows it.
     /// Specifies that an input argument was not null when the call returns.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
-    internal sealed class NotNullAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Parameter |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.ReturnValue,
+        Inherited = false)]
+    internal sealed class NotNullAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute.cs
@@ -10,8 +10,12 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Specifies that the output will be non-null if the named parameter is non-null.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
-    internal sealed class NotNullIfNotNullAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Parameter |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.ReturnValue,
+        AllowMultiple = true, Inherited = false)]
+    internal sealed class NotNullIfNotNullAttribute : global::System.Attribute
     {
         /// <summary>
         /// Initializes the attribute with the associated parameter name.

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.NotNullWhenAttribute.cs
@@ -10,8 +10,8 @@ namespace System.Diagnostics.CodeAnalysis
     /// <summary>
     /// Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    internal sealed class NotNullWhenAttribute : Attribute
+    [global::System.AttributeUsage(global::System.AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class NotNullWhenAttribute : global::System.Attribute
     {
         /// <summary>
         /// Initializes the attribute with the specified return value condition.

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute.cs
@@ -11,8 +11,8 @@ namespace System.Diagnostics.CodeAnalysis
     /// Specifies that this constructor sets all required members for the current type,
     /// and callers do not need to set any required members themselves.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
-    internal sealed class SetsRequiredMembersAttribute : Attribute
+    [global::System.AttributeUsage(global::System.AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    internal sealed class SetsRequiredMembersAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.UnscopedRefAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Diagnostics.CodeAnalysis.UnscopedRefAttribute.cs
@@ -31,11 +31,13 @@ namespace System.Diagnostics.CodeAnalysis
     /// API authors to understand the lifetime implications of applying this attribute and how it may impact their users.
     /// </para>
     /// </remarks>
-    [AttributeUsage(
-        AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Parameter,
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Parameter,
         AllowMultiple = false,
         Inherited = false)]
-    internal sealed class UnscopedRefAttribute : Attribute
+    internal sealed class UnscopedRefAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Index.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Index.cs
@@ -5,9 +5,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-
 namespace System
 {
     /// <summary>Represent a type can be used to index a collection either from the start or the end.</summary>
@@ -18,7 +15,7 @@ namespace System
     /// int lastElement = someArray[^1]; // lastElement = 5
     /// </code>
     /// </remarks>
-    internal readonly struct Index : IEquatable<Index>
+    internal readonly struct Index : global::System.IEquatable<global::System.Index>
     {
         private readonly int _value;
 
@@ -28,12 +25,12 @@ namespace System
         /// <remarks>
         /// If the Index constructed from the end, index value 1 means pointing at the last element and index value 0 means pointing at beyond last element.
         /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public Index(int value, bool fromEnd = false)
         {
             if (value < 0)
             {
-                ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+                global::System.Index.ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
             }
 
             if (fromEnd)
@@ -49,35 +46,35 @@ namespace System
         }
 
         /// <summary>Create an Index pointing at first element.</summary>
-        public static Index Start => new Index(0);
+        public static global::System.Index Start => new global::System.Index(0);
 
         /// <summary>Create an Index pointing at beyond last element.</summary>
-        public static Index End => new Index(~0);
+        public static global::System.Index End => new global::System.Index(~0);
 
         /// <summary>Create an Index from the start at the position indicated by the value.</summary>
         /// <param name="value">The index value from the start.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Index FromStart(int value)
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static global::System.Index FromStart(int value)
         {
             if (value < 0)
             {
-                ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+                global::System.Index.ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
             }
 
-            return new Index(value);
+            return new global::System.Index(value);
         }
 
         /// <summary>Create an Index from the end at the position indicated by the value.</summary>
         /// <param name="value">The index value from the end.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Index FromEnd(int value)
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        public static global::System.Index FromEnd(int value)
         {
             if (value < 0)
             {
-                ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
+                global::System.Index.ThrowHelper.ThrowValueArgumentOutOfRange_NeedNonNegNumException();
             }
 
-            return new Index(~value);
+            return new global::System.Index(~value);
         }
 
         /// <summary>Returns the index value.</summary>
@@ -103,7 +100,7 @@ namespace System
         /// It is expected Index will be used with collections which always have non negative length/count. If the returned offset is negative and
         /// then used to index a collection will get out of range exception which will be same affect as the validation.
         /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public int GetOffset(int length)
         {
             int offset = _value;
@@ -120,17 +117,17 @@ namespace System
 
         /// <summary>Indicates whether the current Index object is equal to another object of the same type.</summary>
         /// <param name="value">An object to compare with this object</param>
-        public override bool Equals([NotNullWhen(true)] object? value) => value is Index && _value == ((Index)value)._value;
+        public override bool Equals([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? value) => value is global::System.Index && _value == ((global::System.Index)value)._value;
 
         /// <summary>Indicates whether the current Index object is equal to another Index object.</summary>
         /// <param name="other">An object to compare with this object</param>
-        public bool Equals(Index other) => _value == other._value;
+        public bool Equals(global::System.Index other) => _value == other._value;
 
         /// <summary>Returns the hash code for this instance.</summary>
         public override int GetHashCode() => _value;
 
         /// <summary>Converts integer number to an Index.</summary>
-        public static implicit operator Index(int value) => FromStart(value);
+        public static implicit operator global::System.Index(int value) => FromStart(value);
 
         /// <summary>Converts the value of the current Index object to its equivalent string representation.</summary>
         public override string ToString()
@@ -148,10 +145,10 @@ namespace System
 
         private static class ThrowHelper
         {
-            [DoesNotReturn]
+            [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
             public static void ThrowValueArgumentOutOfRange_NeedNonNegNumException()
             {
-                throw new ArgumentOutOfRangeException("value", "Non-negative number required.");
+                throw new global::System.ArgumentOutOfRangeException("value", "Non-negative number required.");
             }
         }
     }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Range.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Range.cs
@@ -5,9 +5,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-
 namespace System
 {
     /// <summary>Represent a range has start and end indexes.</summary>
@@ -19,18 +16,18 @@ namespace System
     /// int[] subArray2 = someArray[1..^0]; // { 2, 3, 4, 5 }
     /// </code>
     /// </remarks>
-    internal readonly struct Range : IEquatable<Range>
+    internal readonly struct Range : global::System.IEquatable<global::System.Range>
     {
         /// <summary>Represent the inclusive start index of the Range.</summary>
-        public Index Start { get; }
+        public global::System.Index Start { get; }
 
         /// <summary>Represent the exclusive end index of the Range.</summary>
-        public Index End { get; }
+        public global::System.Index End { get; }
 
         /// <summary>Construct a Range object using the start and end indexes.</summary>
         /// <param name="start">Represent the inclusive start index of the range.</param>
         /// <param name="end">Represent the exclusive end index of the range.</param>
-        public Range(Index start, Index end)
+        public Range(global::System.Index start, global::System.Index end)
         {
             Start = start;
             End = end;
@@ -38,19 +35,19 @@ namespace System
 
         /// <summary>Indicates whether the current Range object is equal to another object of the same type.</summary>
         /// <param name="value">An object to compare with this object</param>
-        public override bool Equals([NotNullWhen(true)] object? value) =>
-            value is Range r &&
+        public override bool Equals([global::System.Diagnostics.CodeAnalysis.NotNullWhen(true)] object? value) =>
+            value is global::System.Range r &&
             r.Start.Equals(Start) &&
             r.End.Equals(End);
 
         /// <summary>Indicates whether the current Range object is equal to another Range object.</summary>
         /// <param name="other">An object to compare with this object</param>
-        public bool Equals(Range other) => other.Start.Equals(Start) && other.End.Equals(End);
+        public bool Equals(global::System.Range other) => other.Start.Equals(Start) && other.End.Equals(End);
 
         /// <summary>Returns the hash code for this instance.</summary>
         public override int GetHashCode()
         {
-            return HashHelpers.Combine(Start.GetHashCode(), End.GetHashCode());
+            return global::System.Range.HashHelpers.Combine(Start.GetHashCode(), End.GetHashCode());
         }
 
         /// <summary>Converts the value of the current Range object to its equivalent string representation.</summary>
@@ -60,13 +57,13 @@ namespace System
         }
 
         /// <summary>Create a Range object starting from start index to the end of the collection.</summary>
-        public static Range StartAt(Index start) => new Range(start, Index.End);
+        public static global::System.Range StartAt(global::System.Index start) => new global::System.Range(start, global::System.Index.End);
 
         /// <summary>Create a Range object starting from first element in the collection to the end Index.</summary>
-        public static Range EndAt(Index end) => new Range(Index.Start, end);
+        public static global::System.Range EndAt(global::System.Index end) => new global::System.Range(global::System.Index.Start, end);
 
         /// <summary>Create a Range object starting from first element to the end.</summary>
-        public static Range All => new Range(Index.Start, Index.End);
+        public static global::System.Range All => new global::System.Range(global::System.Index.Start, global::System.Index.End);
 
         /// <summary>Calculate the start offset and length of range object using a collection length.</summary>
         /// <param name="length">The length of the collection that the range will be used with. length has to be a positive value.</param>
@@ -75,18 +72,18 @@ namespace System
         /// It is expected Range will be used with collections which always have non negative length/count.
         /// We validate the range is inside the length scope though.
         /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
         public (int Offset, int Length) GetOffsetAndLength(int length)
         {
             int start;
-            Index startIndex = Start;
+            global::System.Index startIndex = Start;
             if (startIndex.IsFromEnd)
                 start = length - startIndex.Value;
             else
                 start = startIndex.Value;
 
             int end;
-            Index endIndex = End;
+            global::System.Index endIndex = End;
             if (endIndex.IsFromEnd)
                 end = length - endIndex.Value;
             else
@@ -94,7 +91,7 @@ namespace System
 
             if ((uint)end > (uint)length || (uint)start > (uint)end)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException();
+                global::System.Range.ThrowHelper.ThrowArgumentOutOfRangeException();
             }
 
             return (start, end - start);
@@ -111,10 +108,10 @@ namespace System
 
         private static class ThrowHelper
         {
-            [DoesNotReturn]
+            [global::System.Diagnostics.CodeAnalysis.DoesNotReturn]
             public static void ThrowArgumentOutOfRangeException()
             {
-                throw new ArgumentOutOfRangeException("length");
+                throw new global::System.ArgumentOutOfRangeException("length");
             }
         }
     }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.AsyncMethodBuilderAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.AsyncMethodBuilderAttribute.cs
@@ -12,14 +12,21 @@ namespace System.Runtime.CompilerServices
     /// build the attributed async method or to build the attributed type when used as the return type
     /// of an async method.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Delegate | AttributeTargets.Enum | AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
-    public sealed class AsyncMethodBuilderAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Struct |
+        global::System.AttributeTargets.Interface |
+        global::System.AttributeTargets.Delegate |
+        global::System.AttributeTargets.Enum |
+        global::System.AttributeTargets.Method,
+        Inherited = false, AllowMultiple = false)]
+    public sealed class AsyncMethodBuilderAttribute : global::System.Attribute
     {
-        /// <summary>Initializes the <see cref="AsyncMethodBuilderAttribute"/>.</summary>
-        /// <param name="builderType">The <see cref="Type"/> of the associated builder.</param>
-        public AsyncMethodBuilderAttribute(Type builderType) => BuilderType = builderType;
+        /// <summary>Initializes the <see cref="global::System.Runtime.CompilerServices.AsyncMethodBuilderAttribute"/>.</summary>
+        /// <param name="builderType">The <see cref="global::System.Type"/> of the associated builder.</param>
+        public AsyncMethodBuilderAttribute(global::System.Type builderType) => BuilderType = builderType;
 
-        /// <summary>Gets the <see cref="Type"/> of the associated builder.</summary>
-        public Type BuilderType { get; }
+        /// <summary>Gets the <see cref="global::System.Type"/> of the associated builder.</summary>
+        public global::System.Type BuilderType { get; }
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.CallerArgumentExpressionAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.CallerArgumentExpressionAttribute.cs
@@ -11,11 +11,11 @@ namespace System.Runtime.CompilerServices
     /// An attribute that allows parameters to receive the expression of other parameters.
     /// </summary>
     /// <remarks>Internal copy from the BCL attribute.</remarks>
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    internal sealed class CallerArgumentExpressionAttribute : Attribute
+    [global::System.AttributeUsage(global::System.AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    internal sealed class CallerArgumentExpressionAttribute : global::System.Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CallerArgumentExpressionAttribute"/> class.
+        /// Initializes a new instance of the <see cref="global::System.Runtime.CompilerServices.CallerArgumentExpressionAttribute"/> class.
         /// </summary>
         /// <param name="parameterName">The condition parameter value.</param>
         public CallerArgumentExpressionAttribute(string parameterName)

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute.cs
@@ -10,11 +10,11 @@ namespace System.Runtime.CompilerServices
     /// <summary>
     /// Indicates that compiler support for a particular feature is required for the location where this attribute is applied.
     /// </summary>
-    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
-    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    [global::System.AttributeUsage(global::System.AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : global::System.Attribute
     {
         /// <summary>
-        /// Creates a new instance of the <see cref="CompilerFeatureRequiredAttribute"/> type.
+        /// Creates a new instance of the <see cref="global::System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute"/> type.
         /// </summary>
         /// <param name="featureName">The name of the feature to indicate.</param>
         public CompilerFeatureRequiredAttribute(string featureName)

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute.cs
@@ -10,11 +10,11 @@ namespace System.Runtime.CompilerServices
     /// <summary>
     /// Indicates which arguments to a method involving an interpolated string handler should be passed to that handler.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
-    internal sealed class InterpolatedStringHandlerArgumentAttribute : Attribute
+    [global::System.AttributeUsage(global::System.AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    internal sealed class InterpolatedStringHandlerArgumentAttribute : global::System.Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="InterpolatedStringHandlerArgumentAttribute"/> class.
+        /// Initializes a new instance of the <see cref="global::System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute"/> class.
         /// </summary>
         /// <param name="argument">The name of the argument that should be passed to the handler.</param>
         /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>
@@ -24,7 +24,7 @@ namespace System.Runtime.CompilerServices
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InterpolatedStringHandlerArgumentAttribute"/> class.
+        /// Initializes a new instance of the <see cref="global::System.Runtime.CompilerServices.InterpolatedStringHandlerArgumentAttribute"/> class.
         /// </summary>
         /// <param name="arguments">The names of the arguments that should be passed to the handler.</param>
         /// <remarks><see langword="null"/> may be used as the name of the receiver in an instance method.</remarks>

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute.cs
@@ -10,8 +10,11 @@ namespace System.Runtime.CompilerServices
     /// <summary>
     /// Indicates the attributed type is to be used as an interpolated string handler.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
-    internal sealed class InterpolatedStringHandlerAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Struct,
+        AllowMultiple = false, Inherited = false)]
+    internal sealed class InterpolatedStringHandlerAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.IsExternalInit.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.IsExternalInit.cs
@@ -5,15 +5,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.ComponentModel;
-
 namespace System.Runtime.CompilerServices
 {
     /// <summary>
     /// Reserved to be used by the compiler for tracking metadata.
     /// This class should not be used by developers in source code.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never)]
+    [global::System.ComponentModel.EditorBrowsable(global::System.ComponentModel.EditorBrowsableState.Never)]
     internal static class IsExternalInit
     {
     }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.RequiredMemberAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.RequiredMemberAttribute.cs
@@ -10,14 +10,14 @@ namespace System.Runtime.CompilerServices
     /// <summary>
     /// Specifies that a type has required members or that a member is required.
     /// </summary>
-    [AttributeUsage(
-        AttributeTargets.Class |
-        AttributeTargets.Struct |
-        AttributeTargets.Field |
-        AttributeTargets.Property,
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Struct |
+        global::System.AttributeTargets.Field |
+        global::System.AttributeTargets.Property,
         AllowMultiple = false,
         Inherited = false)]
-    internal sealed class RequiredMemberAttribute : Attribute
+    internal sealed class RequiredMemberAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.SkipLocalsInitAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.SkipLocalsInitAttribute.cs
@@ -10,17 +10,17 @@ namespace System.Runtime.CompilerServices
     /// <summary>
     /// Used to indicate to the compiler that the <c>.locals init</c> flag should not be set in method headers.
     /// </summary>
-    [AttributeUsage(
-        AttributeTargets.Module |
-        AttributeTargets.Class |
-        AttributeTargets.Struct |
-        AttributeTargets.Interface |
-        AttributeTargets.Constructor |
-        AttributeTargets.Method |
-        AttributeTargets.Property |
-        AttributeTargets.Event,
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Module |
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Struct |
+        global::System.AttributeTargets.Interface |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Event,
         Inherited = false)]
-    internal sealed class SkipLocalsInitAttribute : Attribute
+    internal sealed class SkipLocalsInitAttribute : global::System.Attribute
     {
     }
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.Versioning.RequiresPreviewFeaturesAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.Versioning.RequiresPreviewFeaturesAttribute.cs
@@ -7,27 +7,28 @@
 
 namespace System.Runtime.Versioning
 {
-    [AttributeUsage(AttributeTargets.Assembly |
-                AttributeTargets.Module |
-                AttributeTargets.Class |
-                AttributeTargets.Interface |
-                AttributeTargets.Delegate |
-                AttributeTargets.Struct |
-                AttributeTargets.Enum |
-                AttributeTargets.Constructor |
-                AttributeTargets.Method |
-                AttributeTargets.Property |
-                AttributeTargets.Field |
-                AttributeTargets.Event, Inherited = false)]
-    internal sealed class RequiresPreviewFeaturesAttribute : Attribute
+    [global::System.AttributeUsage(
+        global::System.AttributeTargets.Assembly |
+        global::System.AttributeTargets.Module |
+        global::System.AttributeTargets.Class |
+        global::System.AttributeTargets.Interface |
+        global::System.AttributeTargets.Delegate |
+        global::System.AttributeTargets.Struct |
+        global::System.AttributeTargets.Enum |
+        global::System.AttributeTargets.Constructor |
+        global::System.AttributeTargets.Method |
+        global::System.AttributeTargets.Property |
+        global::System.AttributeTargets.Field |
+        AttributeTargets.Event, Inherited = false)]
+    internal sealed class RequiresPreviewFeaturesAttribute : global::System.Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="RequiresPreviewFeaturesAttribute"/> class.
+        /// Initializes a new instance of the <see cref="global::System.Runtime.Versioning.RequiresPreviewFeaturesAttribute"/> class.
         /// </summary>
         public RequiresPreviewFeaturesAttribute() { }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RequiresPreviewFeaturesAttribute"/> class with the specified message.
+        /// Initializes a new instance of the <see cref="global::System.Runtime.Versioning.RequiresPreviewFeaturesAttribute"/> class with the specified message.
         /// </summary>
         /// <param name="message">An optional message associated with this attribute instance.</param>
         public RequiresPreviewFeaturesAttribute(string? message)


### PR DESCRIPTION
### Description

This PR uses `global::` prefixes and fully qualified type names everywhere in all generated polyfills.
This follows the recommended practice for generated code and avoids potential issues with global usings.