### PR TITLE
Handle C# 8.0 as minimum version

### DIFF
--- a/PolySharp.sln
+++ b/PolySharp.sln
@@ -33,6 +33,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D78D3FFF-DB8
 		src\Directory.Build.targets = src\Directory.Build.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PolySharp.MinimumCSharpVersion.Tests", "tests\PolySharp.MinimumCSharpVersion.Tests\PolySharp.MinimumCSharpVersion.Tests.csproj", "{B9459D6D-247C-435D-9642-D6A933ECEECC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{41EC2F2E-797F-486A-8E2E-1788C7CF0DF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{41EC2F2E-797F-486A-8E2E-1788C7CF0DF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41EC2F2E-797F-486A-8E2E-1788C7CF0DF3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9459D6D-247C-435D-9642-D6A933ECEECC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9459D6D-247C-435D-9642-D6A933ECEECC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9459D6D-247C-435D-9642-D6A933ECEECC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9459D6D-247C-435D-9642-D6A933ECEECC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -54,6 +60,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{41EC2F2E-797F-486A-8E2E-1788C7CF0DF3} = {D65D0307-1D0F-499D-945B-E33E71F251A4}
 		{D78D3FFF-DB82-41B3-951F-40C7ED8F8F07} = {C0C25293-DF18-48E5-BCE9-499CB6D66BB6}
+		{B9459D6D-247C-435D-9642-D6A933ECEECC} = {D65D0307-1D0F-499D-945B-E33E71F251A4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F946EBAA-2D9B-4599-B4A2-7ECD81E0DF61}

--- a/src/PolySharp.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/PolySharp.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -9,3 +9,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 POLYSP0001 | PolySharp.SourceGenerators.InvalidPolySharpMSBuildOptionAnalyzer | Warning | See https://github.com/Sergio0694/PolySharp
 POLYSP0002 | PolySharp.SourceGenerators.InvalidPolySharpMSBuildOptionAnalyzer | Warning | See https://github.com/Sergio0694/PolySharp
+POLYSP0003 | PolySharp.SourceGenerators.UnsupportedCSharpLanguageVersionAnalyzer | Warning | See https://github.com/Sergio0694/PolySharp

--- a/src/PolySharp.SourceGenerators/Diagnostics/Analyzers/UnsupportedCSharpLanguageVersionAnalyzer.Execute.cs
+++ b/src/PolySharp.SourceGenerators/Diagnostics/Analyzers/UnsupportedCSharpLanguageVersionAnalyzer.Execute.cs
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using PolySharp.SourceGenerators.Extensions;
+using PolySharp.SourceGenerators.Models;
+using static PolySharp.SourceGenerators.Diagnostics.DiagnosticDescriptors;
+
+namespace PolySharp.SourceGenerators;
+
+/// <inheritdoc/>
+partial class UnsupportedCSharpLanguageVersionAnalyzer
+{
+    /// <summary>
+    /// Extracts the <see cref="DiagnosticInfo"/> values for the current generation.
+    /// </summary>
+    /// <param name="compilation">The input <see cref="Compilation"/> instance.</param>
+    /// <param name="token">The cancellation token for the operation.</param>
+    /// <returns>The <see cref="DiagnosticInfo"/> values for the current generation.</returns>
+    private static ImmutableArray<DiagnosticInfo> GetOptionsDiagnostics(Compilation compilation, CancellationToken token)
+    {
+        // Check that the language version is not high enough, otherwise no diagnostic should ever be produced
+        if (!compilation.HasLanguageVersionAtLeastEqualTo(LanguageVersion.CSharp8))
+        {
+            return ImmutableArray.Create(DiagnosticInfo.Create(UnsupportedCSharpLanguageVersionError));
+        }
+
+        return ImmutableArray<DiagnosticInfo>.Empty;
+    }
+}

--- a/src/PolySharp.SourceGenerators/Diagnostics/Analyzers/UnsupportedCSharpLanguageVersionAnalyzer.cs
+++ b/src/PolySharp.SourceGenerators/Diagnostics/Analyzers/UnsupportedCSharpLanguageVersionAnalyzer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using PolySharp.SourceGenerators.Extensions;
 using PolySharp.SourceGenerators.Models;
@@ -9,21 +10,21 @@ using PolySharp.SourceGenerators.Models;
 namespace PolySharp.SourceGenerators;
 
 /// <summary>
-/// A diagnostic analyzer that generates warnings whenever a PolySharp MSBuild property is set incorrectly.
+/// A diagnostic analyzer that generates an error whenever a source-generator attribute is used with not high enough C# version enabled.
 /// </summary>
 /// <remarks>
 /// This has to be a generator because emitting diagnostics for analyzer options from an analyzer is not currently supported.
 /// See <see href="https://github.com/dotnet/roslyn/issues/64213"/>.
 /// </remarks>
 [Generator(LanguageNames.CSharp)]
-public sealed partial class InvalidPolySharpMSBuildOptionAnalyzer : IIncrementalGenerator
+public sealed partial class UnsupportedCSharpLanguageVersionAnalyzer : IIncrementalGenerator
 {
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         // Prepare all the diagnostics for the analyzer options being used
         IncrementalValuesProvider<DiagnosticInfo> analyzerOptionsDiagnostics =
-            context.AnalyzerConfigOptionsProvider
+            context.CompilationProvider
             .SelectMany(GetOptionsDiagnostics);
 
         // Output the diagnostics

--- a/src/PolySharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
+++ b/src/PolySharp.SourceGenerators/Diagnostics/DiagnosticDescriptors.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 #pragma warning disable IDE0090 // Use 'new DiagnosticDescriptor(...)'
 
@@ -43,5 +44,18 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Only fully qualified metadata names for existing polyfill types should be used as options to configure PolySharp's generation.",
+        helpLinkUri: "https://github.com/Sergio0694/PolySharp");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating when an unsupported C# language version is being used.
+    /// </summary>
+    public static readonly DiagnosticDescriptor UnsupportedCSharpLanguageVersionError = new DiagnosticDescriptor(
+        id: "POLYSP0003",
+        title: "Unsupported C# language version",
+        messageFormat: "The source generator features from PolySharp require consuming projects to set the C# language version to at least C# 8.0",
+        category: typeof(CSharpParseOptions).FullName,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The source generator features from PolySharp require consuming projects to set the C# language version to at least C# 8.0. Make sure to add <LangVersion>8.0</LangVersion> (or above) to your .csproj file.",
         helpLinkUri: "https://github.com/Sergio0694/PolySharp");
 }

--- a/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute.cs
@@ -30,7 +30,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// If true, the compiler can choose to allow access to the location where this attribute is applied if it does not understand <see cref="FeatureName"/>.
         /// </summary>
-        public bool IsOptional { get; init; }
+        public bool IsOptional { get; set; }
 
         /// <summary>
         /// The <see cref="FeatureName"/> used for the ref structs C# feature.

--- a/src/PolySharp.SourceGenerators/Extensions/CompilationExtensions.cs
+++ b/src/PolySharp.SourceGenerators/Extensions/CompilationExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace PolySharp.SourceGenerators.Extensions;
 
@@ -11,6 +12,17 @@ namespace PolySharp.SourceGenerators.Extensions;
 /// </summary>
 internal static class CompilationExtensions
 {
+    /// <summary>
+    /// Checks whether a given compilation (assumed to be for C#) is using at least a given language version.
+    /// </summary>
+    /// <param name="compilation">The <see cref="Compilation"/> to consider for analysis.</param>
+    /// <param name="languageVersion">The minimum language version to check.</param>
+    /// <returns>Whether <paramref name="compilation"/> is using at least the specified language version.</returns>
+    public static bool HasLanguageVersionAtLeastEqualTo(this Compilation compilation, LanguageVersion languageVersion)
+    {
+        return ((CSharpCompilation)compilation).LanguageVersion >= languageVersion;
+    }
+
     /// <summary>
     /// <para>
     /// Checks whether or not a type with a specified metadata name is accessible from a given <see cref="Compilation"/> instance.

--- a/src/PolySharp.SourceGenerators/PolyfillsGenerator.Execute.cs
+++ b/src/PolySharp.SourceGenerators/PolyfillsGenerator.Execute.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using PolySharp.SourceGenerators.Constants;
@@ -85,6 +86,12 @@ partial class PolyfillsGenerator
     /// <returns>The collection of <see cref="GeneratedType"/>-s to emit.</returns>
     private static ImmutableArray<GeneratedType> GetGeneratedTypes((Compilation Compilation, GenerationOptions Options) info, CancellationToken token)
     {
+        // A minimum of C# 8.0 is required to benefit from the polyfills
+        if (!info.Compilation.HasLanguageVersionAtLeastEqualTo(LanguageVersion.CSharp8))
+        {
+            return ImmutableArray<GeneratedType>.Empty;
+        }
+
         // Helper function to check whether a type should be included for generation
         static bool ShouldIncludeGeneratedType(Compilation compilation, GenerationOptions options, string name, CancellationToken token)
         {

--- a/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
+++ b/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
@@ -8,7 +8,7 @@ namespace PolySharp.SourceGenerators;
 /// A source generator injecting all needed C# polyfills at compile time.
 /// </summary>
 [Generator(LanguageNames.CSharp)]
-internal sealed partial class PolyfillsGenerator : IIncrementalGenerator
+public sealed partial class PolyfillsGenerator : IIncrementalGenerator
 {
     /// <inheritdoc/>
     public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/tests/PolySharp.MinimumCSharpVersion.Tests/PolySharp.MinimumCSharpVersion.Tests.csproj
+++ b/tests/PolySharp.MinimumCSharpVersion.Tests/PolySharp.MinimumCSharpVersion.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PolySharp.SourceGenerators\PolySharp.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Closes #14

### Description

This PR does two things:
- Ensures all polyfills build with C# 8.0
- Skips polyfills with C# < 8.0 and emits a warning instead