### PR TITLE
Make package a development dependency

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -70,6 +70,7 @@
 
   <PropertyGroup>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_RUN_ID)' != ''">true</ContinuousIntegrationBuild>
+    <DevelopmentDependency>true</DevelopmentDependency>
     <RepositoryUrl>https://github.com/Sergio0694/PolySharp/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,6 +2,6 @@
   <Import Project="..\Directory.Build.props" />
 
   <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="0.9.0" PrivateAssets="all" />
+    <PackageReference Include="NuGetizer" Version="0.9.1" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Needs a bump in nugetizer for the compatible property to work (used to require IsDevelopmentDependency).

Fixes #19