### PR TITLE
Specify the minimum .NET 6 SDK

### DIFF
--- a/src/PolySharp.SourceGenerators/PolySharp.targets
+++ b/src/PolySharp.SourceGenerators/PolySharp.targets
@@ -42,7 +42,7 @@
       emitting this manually lets us customize the message to inform developers as to why exactly the generators have been
       disabled, and that PolySharp will not work at all unless a more up to date IDE or compiler version are used.
     -->
-    <Error Condition ="'$(PolySharpCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The PolySharp source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. PolySharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.3 or greater) or .NET SDK version (.NET 6 SDK or greater)."/>  
+    <Error Condition ="'$(PolySharpCurrentCompilerVersionIsNotNewEnough)' == 'true'" Text="The PolySharp source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. PolySharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.3 or greater) or .NET SDK version (.NET 6.0.400 SDK or greater)."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->


### PR DESCRIPTION
### Description

Clarify that .NET SDK 6.0.400, which which shipped with VS 17.3, is the minimum SDK.
E.g. 6.0.302 does not not work even though ".NET 6 SDK or greater" might make you think so.