### PR TITLE
Add workarounds to support .NET 3.5

### DIFF
--- a/src/PolySharp.SourceGenerators/Models/GeneratedType.cs
+++ b/src/PolySharp.SourceGenerators/Models/GeneratedType.cs
@@ -5,4 +5,8 @@ namespace PolySharp.SourceGenerators.Models;
 /// </summary>
 /// <param name="FullyQualifiedMetadataName">The fully qualified type name of the type to generate.</param>
 /// <param name="IsPublicAccessibilityRequired">Whether to use public accessibility for the generated type.</param>
-internal sealed record GeneratedType(string FullyQualifiedMetadataName, bool IsPublicAccessibilityRequired);
+/// <param name="FixupType">The types of syntax fixups to apply.</param>
+internal sealed record GeneratedType(
+    string FullyQualifiedMetadataName,
+    bool IsPublicAccessibilityRequired,
+    SyntaxFixupType FixupType);

--- a/src/PolySharp.SourceGenerators/Models/SyntaxFixupType.cs
+++ b/src/PolySharp.SourceGenerators/Models/SyntaxFixupType.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace PolySharp.SourceGenerators.Models;
+
+/// <summary>
+/// An enum indicating a type of syntax fixup to apply to a generated source.
+/// </summary>
+[Flags]
+internal enum SyntaxFixupType
+{
+    /// <summary>
+    /// No syntax fixup is needed
+    /// </summary>
+    None = 0x0,
+
+    /// <summary>
+    /// Remove all <c>[MethodImpl]</c> attributes.
+    /// </summary>
+    RemoveMethodImplAttributes = 0x1
+}

--- a/src/PolySharp.SourceGenerators/PolyfillsGenerator.Execute.cs
+++ b/src/PolySharp.SourceGenerators/PolyfillsGenerator.Execute.cs
@@ -49,6 +49,11 @@ partial class PolyfillsGenerator
         select Regex.Match(resourceName, EmbeddedResourceNameToFullyQualifiedTypeNameRegex).Groups[1].Value);
 
     /// <summary>
+    /// The <see cref="Regex"/> to find all <see cref="System.Runtime.CompilerServices.MethodImplOptions"/> uses.
+    /// </summary>
+    private static readonly Regex MethodImplOptionsRegex = new(@" *\[global::System\.Runtime\.CompilerServices\.MethodImpl\(global::System\.Runtime\.CompilerServices\.MethodImplOptions\.AggressiveInlining\)\]\r?\n", RegexOptions.Compiled);
+
+    /// <summary>
     /// The dictionary of cached sources to produce.
     /// </summary>
     private readonly ConcurrentDictionary<GeneratedType, SourceText> manifestSources = new();
@@ -127,6 +132,21 @@ partial class PolyfillsGenerator
             return true;
         }
 
+        // Helper to get the syntax fixup to apply to a given type
+        static SyntaxFixupType GetSyntaxFixupType(Compilation compilation, GenerationOptions options, string name)
+        {
+            if (name is "System.Range" or "System.Index")
+            {
+                // If MethodImplOptions.AggressiveInlining isn't found, remove the attribute
+                if (compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.MethodImplOptions")?.GetMembers("AggressiveInlining") is not [IFieldSymbol])
+                {
+                    return SyntaxFixupType.RemoveMethodImplAttributes;
+                }
+            }
+
+            return SyntaxFixupType.None;
+        }
+
         using ImmutableArrayBuilder<GeneratedType> builder = ImmutableArrayBuilder<GeneratedType>.Rent();
 
         // First go through the language support types
@@ -134,7 +154,7 @@ partial class PolyfillsGenerator
         {
             if (ShouldIncludeGeneratedType(info.Compilation, info.Options, name, token))
             {
-                builder.Add(new GeneratedType(name, info.Options.UsePublicAccessibilityForGeneratedTypes));
+                builder.Add(new GeneratedType(name, info.Options.UsePublicAccessibilityForGeneratedTypes, GetSyntaxFixupType(info.Compilation, info.Options, name)));
             }
         }
 
@@ -147,7 +167,7 @@ partial class PolyfillsGenerator
             {
                 if (ShouldIncludeGeneratedType(info.Compilation, info.Options, name, token))
                 {
-                    builder.Add(new GeneratedType(name, info.Options.UsePublicAccessibilityForGeneratedTypes));
+                    builder.Add(new GeneratedType(name, info.Options.UsePublicAccessibilityForGeneratedTypes, GetSyntaxFixupType(info.Compilation, info.Options, name)));
                 }
             }
         }
@@ -169,17 +189,31 @@ partial class PolyfillsGenerator
 
             using Stream stream = typeof(PolyfillsGenerator).Assembly.GetManifestResourceStream(resourceName);
 
-            // If public accessibility has been requested, we need to update the loaded source files
-            if (type.IsPublicAccessibilityRequired)
+            // If public accessibility has been requested or a syntax fixup is needed, we need to update the loaded source files
+            if (type is { IsPublicAccessibilityRequired: true } or { FixupType: not SyntaxFixupType.None })
             {
-                using StreamReader reader = new(stream);
+                string adjustedSource;
 
-                // Read the source and replace all internal keywords with public. Use a space before and after the identifier
-                // to avoid potential false positives. This could also be done by loading the source tree and using a syntax
-                // rewriter, or just by retrieving the type declaration syntax and updating the modifier tokens, but since the
-                // change is so minimal, it can very well just be done this way to keep things simple, that's fine in this case.
-                string originalSource = reader.ReadToEnd();
-                string adjustedSource = originalSource.Replace(" internal ", " public ");
+                using (StreamReader reader = new(stream))
+                {
+                    adjustedSource = reader.ReadToEnd();
+                }
+
+                if (type.IsPublicAccessibilityRequired)
+                {
+                    // After reading the file, replace all internal keywords with public. Use a space before and after the identifier
+                    // to avoid potential false positives. This could also be done by loading the source tree and using a syntax
+                    // rewriter, or just by retrieving the type declaration syntax and updating the modifier tokens, but since the
+                    // change is so minimal, it can very well just be done this way to keep things simple, that's fine in this case.
+                    adjustedSource = adjustedSource.Replace(" internal ", " public ");
+                }
+
+                if (type.FixupType == SyntaxFixupType.RemoveMethodImplAttributes)
+                {
+                    // Just use a regex to remove the attribute. We could use a SyntaxRewriter, but we don't really have that many
+                    // cases to handle for now, so once again we can just use the simplest approach for the time being, that's fine.
+                    adjustedSource = MethodImplOptionsRegex.Replace(adjustedSource, "");
+                }
 
                 sourceText = SourceText.From(adjustedSource, Encoding.UTF8);
             }

--- a/src/PolySharp.SourceGenerators/PolyfillsGenerator.Execute.cs
+++ b/src/PolySharp.SourceGenerators/PolyfillsGenerator.Execute.cs
@@ -113,7 +113,18 @@ partial class PolyfillsGenerator
             }
 
             // Otherwise, check that the type is not in the list of excluded types
-            return !options.ExcludeGeneratedTypes.AsImmutableArray().Contains(name);
+            if (options.ExcludeGeneratedTypes.AsImmutableArray().Contains(name))
+            {
+                return false;
+            }
+
+            // Special case System.Range on System.ValueTuple`2 existing
+            if (name is "System.Range")
+            {
+                return compilation.GetTypeByMetadataName("System.ValueTuple`2") is not null;
+            }
+
+            return true;
         }
 
         using ImmutableArrayBuilder<GeneratedType> builder = ImmutableArrayBuilder<GeneratedType>.Rent();

--- a/tests/PolySharp.NuGet/PolySharp.NuGet.csproj
+++ b/tests/PolySharp.NuGet/PolySharp.NuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net48;net481;netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
       ..\..\artifacts;
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="PolySharp" Version="$(PackageVersion)" />
-    <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net48' OR '$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Closes #28

### Description

This PR adds a couple workarounds to also support .NET 3.5:
- Strip the `[MethodImpl]` attributes when the target option isn't present
- Skip generating `System.Range` if `System.ValueTuple`2` isn't present