### PR TITLE
Fix README.md being packed twice

### DIFF
--- a/src/PolySharp.Package/PolySharp.Package.msbuildproj
+++ b/src/PolySharp.Package/PolySharp.Package.msbuildproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="icon.png" PackFolder="\" />
-    <None Include="..\..\README.md" PackFolder="\" />
+    <None Include="icon.png" PackagePath="icon.png" Pack="true" />
+    <None Include="..\..\README.md" PackagePath="README.md" Pack="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Closes https://github.com/NuGet/NuGetGallery/issues/9343

### Description

This PR fixes the README.md file being packed twice when creating the NuGet package.