### PR TITLE
Refactor pipeline to not flow Compilation objects

### DIFF
--- a/src/PolySharp.SourceGenerators/Models/AvailableType.cs
+++ b/src/PolySharp.SourceGenerators/Models/AvailableType.cs
@@ -1,0 +1,8 @@
+namespace PolySharp.SourceGenerators.Models;
+
+/// <summary>
+/// A model to hold information on an available type that could be generated, if requested.
+/// </summary>
+/// <param name="FullyQualifiedMetadataName">The fully qualified type name of the type.</param>
+/// <param name="FixupType">The types of syntax fixups to apply if the type is generated.</param>
+internal sealed record AvailableType(string FullyQualifiedMetadataName, SyntaxFixupType FixupType);

--- a/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
+++ b/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
@@ -18,13 +18,19 @@ public sealed partial class PolyfillsGenerator : IIncrementalGenerator
             context.AnalyzerConfigOptionsProvider
             .Select(GetGenerationOptions);
 
-        // Gather the sequence of all types to generate, along with their additional info
-        IncrementalValuesProvider<GeneratedType> requestedTypes =
+        // Get the sequence of all avaailable types that could be generated
+        IncrementalValuesProvider<AvailableType> availableTypes =
             context.CompilationProvider
+            .SelectMany(GetAvailableTypes);
+
+        // Gather the sequence of all types to generate after filtering
+        IncrementalValuesProvider<GeneratedType> generatedTypes =
+            availableTypes
             .Combine(generationOptions)
-            .SelectMany(GetGeneratedTypes);
+            .Where(IsAvailableTypeSelected)
+            .Select(GetGeneratedType);
 
         // Generate source for the current type depending on current accessibility
-        context.RegisterSourceOutput(requestedTypes, EmitGeneratedType);
+        context.RegisterSourceOutput(generatedTypes, EmitGeneratedType);
     }
 }


### PR DESCRIPTION
### Description

This PR refactors the source generator to stop flowing a `Compilation` object into the incremental pipeline.

cc. @Youssef1313 since we were just talking about this, everything looks good? 😄