### PR TITLE
Add PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute MSBuild option

### DIFF
--- a/PolySharp.sln
+++ b/PolySharp.sln
@@ -33,7 +33,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D78D3FFF-DB8
 		src\Directory.Build.targets = src\Directory.Build.targets
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PolySharp.MinimumCSharpVersion.Tests", "tests\PolySharp.MinimumCSharpVersion.Tests\PolySharp.MinimumCSharpVersion.Tests.csproj", "{B9459D6D-247C-435D-9642-D6A933ECEECC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PolySharp.MinimumCSharpVersion.Tests", "tests\PolySharp.MinimumCSharpVersion.Tests\PolySharp.MinimumCSharpVersion.Tests.csproj", "{B9459D6D-247C-435D-9642-D6A933ECEECC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests", "tests\PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests\PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests.csproj", "{C865CEDE-2DC9-4E1E-BB58-529E6E2A9DBB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,6 +55,10 @@ Global
 		{B9459D6D-247C-435D-9642-D6A933ECEECC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B9459D6D-247C-435D-9642-D6A933ECEECC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B9459D6D-247C-435D-9642-D6A933ECEECC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C865CEDE-2DC9-4E1E-BB58-529E6E2A9DBB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C865CEDE-2DC9-4E1E-BB58-529E6E2A9DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C865CEDE-2DC9-4E1E-BB58-529E6E2A9DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C865CEDE-2DC9-4E1E-BB58-529E6E2A9DBB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -61,6 +67,7 @@ Global
 		{41EC2F2E-797F-486A-8E2E-1788C7CF0DF3} = {D65D0307-1D0F-499D-945B-E33E71F251A4}
 		{D78D3FFF-DB82-41B3-951F-40C7ED8F8F07} = {C0C25293-DF18-48E5-BCE9-499CB6D66BB6}
 		{B9459D6D-247C-435D-9642-D6A933ECEECC} = {D65D0307-1D0F-499D-945B-E33E71F251A4}
+		{C865CEDE-2DC9-4E1E-BB58-529E6E2A9DBB} = {D65D0307-1D0F-499D-945B-E33E71F251A4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F946EBAA-2D9B-4599-B4A2-7ECD81E0DF61}

--- a/README.md
+++ b/README.md
@@ -76,5 +76,6 @@ It also includes the following optional runtime-supported polyfills:
 The following properties are available:
 - "PolySharpUsePublicAccessibilityForGeneratedTypes": makes all generated types public.
 - "PolySharpIncludeRuntimeSupportedAttributes": enables polyfills for (dummy) runtime-supported attributes too.
+- "PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute": uses a type alias for `[UnmanagedCallersOnly]`.
 - "PolySharpExcludeGeneratedTypes": excludes specific types from generation (';' or ',' separated type names).
 - "PolySharpIncludeGeneratedTypes": only includes specific types for generation (';' or ',' separated type names).

--- a/src/PolySharp.SourceGenerators/Constants/PolySharpMSBuildProperties.cs
+++ b/src/PolySharp.SourceGenerators/Constants/PolySharpMSBuildProperties.cs
@@ -16,6 +16,11 @@ internal static class PolySharpMSBuildProperties
     public const string IncludeRuntimeSupportedAttributes = "PolySharpIncludeRuntimeSupportedAttributes";
 
     /// <summary>
+    /// The MSBuild property for <see cref="Models.GenerationOptions.UseTypeAliasForUnmanagedCallersOnlyAttribute"/>.
+    /// </summary>
+    public const string UseTypeAliasForUnmanagedCallersOnlyAttribute = "PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute";
+
+    /// <summary>
     /// The MSBuild property for <see cref="Models.GenerationOptions.ExcludeGeneratedTypes"/>.
     /// </summary>
     public const string ExcludeGeneratedTypes = "PolySharpExcludeGeneratedTypes";

--- a/src/PolySharp.SourceGenerators/Models/GenerationOptions.cs
+++ b/src/PolySharp.SourceGenerators/Models/GenerationOptions.cs
@@ -7,10 +7,12 @@ namespace PolySharp.SourceGenerators.Models;
 /// </summary>
 /// <param name="UsePublicAccessibilityForGeneratedTypes">Whether to use public accessibility for the generated types.</param>
 /// <param name="IncludeRuntimeSupportedAttributes">Whether to also generated dummy runtime supported attributes.</param>
+/// <param name="UseTypeAliasForUnmanagedCallersOnlyAttribute">Whether to move the <c>[UnmanagedCallersOnly]</c> type to another namespace and add a type alias for it.</param>
 /// <param name="ExcludeGeneratedTypes">The collection of fully qualified type names of types to exclude from generation.</param>
 /// <param name="IncludeGeneratedTypes">The collection of fully qualified type names of types to include in the generation.</param>
 internal sealed record GenerationOptions(
     bool UsePublicAccessibilityForGeneratedTypes,
     bool IncludeRuntimeSupportedAttributes,
+    bool UseTypeAliasForUnmanagedCallersOnlyAttribute,
     EquatableArray<string> ExcludeGeneratedTypes,
     EquatableArray<string> IncludeGeneratedTypes);

--- a/src/PolySharp.SourceGenerators/Models/SyntaxFixupType.cs
+++ b/src/PolySharp.SourceGenerators/Models/SyntaxFixupType.cs
@@ -11,10 +11,16 @@ internal enum SyntaxFixupType
     /// <summary>
     /// No syntax fixup is needed
     /// </summary>
-    None = 0x0,
+    None = 0,
 
     /// <summary>
     /// Remove all <c>[MethodImpl]</c> attributes.
     /// </summary>
-    RemoveMethodImplAttributes = 0x1
+    RemoveMethodImplAttributes = 1 << 0,
+
+    /// <summary>
+    /// Generates the <c>[UnmanagedCallersOnly]</c> type in a different namespace and adds a <c>global using</c> type alias for it with the same name.
+    /// </summary>
+    /// <remarks>This is needed when methods annotated with the attribute have to be assigned to delegates, which Roslyn will otherwise block.</remarks>
+    AliasUnmanagedCallersOnlyAttributeType = 1 << 1
 }

--- a/src/PolySharp.SourceGenerators/PolySharp.targets
+++ b/src/PolySharp.SourceGenerators/PolySharp.targets
@@ -65,6 +65,7 @@
     <ItemGroup>
       <CompilerVisibleProperty Include="PolySharpUsePublicAccessibilityForGeneratedTypes"/>
       <CompilerVisibleProperty Include="PolySharpIncludeRuntimeSupportedAttributes"/>
+      <CompilerVisibleProperty Include="PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute"/>
       <CompilerVisibleProperty Include="PolySharpExcludeGeneratedTypes"/>
       <CompilerVisibleProperty Include="PolySharpIncludeGeneratedTypes"/>
     </ItemGroup>

--- a/tests/PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests/PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests.csproj
+++ b/tests/PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests/PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+    <PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute>true</PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="PolySharpIncludeRuntimeSupportedAttributes" />
+    <CompilerVisibleProperty Include="PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PolySharp.SourceGenerators\PolySharp.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+  </ItemGroup>
+
+</Project>

--- a/tests/PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests/UnmanagedCallersOnlyAttributeTests.cs
+++ b/tests/PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests/UnmanagedCallersOnlyAttributeTests.cs
@@ -1,0 +1,9 @@
+namespace PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests;
+
+internal class UnmanagedCallersOnlyAttributeTests
+{
+    [global::System.Runtime.InteropServices2.UnmanagedCallersOnly]
+    public static void NativeFunction()
+    {
+    }
+}


### PR DESCRIPTION
### Description

This PR adds a new "PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute" option that will alter the generated `[UnmanagedCallersOnly]` attribute type so that (1) it will be generated in the `System.Runtime.InteropServices2` namespace, and (2) a `global using` type alias for it will be generated (so the dummy namespace will never need to be manually imported in a file). This allows methods annotated with the attribute in a multi-targeted project to be allowed to be assigned to a delegate, without Roslyn blocking the operation and demanding the address of the annotated method to be taken instead.