### PR TITLE
Drop NuGetizer from packaging project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -68,9 +68,9 @@
     <VersionSuffix Condition="'$(GITHUB_EVENT_NAME)' == 'pull_request' AND '$(IsCommitOnReleaseBranch)' != 'true'">pr</VersionSuffix>
   </PropertyGroup>
 
+  <!-- Shared attribution and configuration properties -->
   <PropertyGroup>
     <ContinuousIntegrationBuild Condition="'$(GITHUB_RUN_ID)' != ''">true</ContinuousIntegrationBuild>
-    <DevelopmentDependency>true</DevelopmentDependency>
     <RepositoryUrl>https://github.com/Sergio0694/PolySharp/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -78,11 +78,7 @@
     <Authors>Sergio Pedri</Authors>
     <Owners>Sergio Pedri</Owners>
     <Company>Sergio Pedri</Company>
-    <Copyright>Copyright (c) 2022 Sergio Pedri</Copyright>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageTags>dotnet net netcore netstandard csharp library generator polyfill roslyn</PackageTags>
+    <Copyright>Copyright (c) 2023 Sergio Pedri</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,0 @@
-<Project>
-  <Import Project="..\Directory.Build.props" />
-
-  <ItemGroup>
-    <PackageReference Include="NuGetizer" Version="0.9.1" PrivateAssets="all" />
-  </ItemGroup>
-</Project>

--- a/src/PolySharp.Package/PolySharp.Package.msbuildproj
+++ b/src/PolySharp.Package/PolySharp.Package.msbuildproj
@@ -2,6 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+
+    <!--
+      This ignores the following warning:
+      "NU5128: some target frameworks declared in the dependencies group of the nuspec and the lib/ref folder do not
+      have exact matches in the other location. [...] Add lib or ref assemblies for the netstandard2.0 target framework."
+      This happens because the package only includes an analyzer, and no binaries to reference at runtime at all.
+    -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -12,19 +20,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="icon.png" PackagePath="icon.png" Pack="true" />
-    <None Include="README.md" PackagePath="README.md" Pack="true" />
+    <None Include="icon.png" PackagePath="\" Pack="true" />
+    <None Include="README.md" PackagePath="\" Pack="true" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\PolySharp.SourceGenerators\PolySharp.SourceGenerators.csproj" PackFolder="analyzers\dotnet\cs" />
+    <ProjectReference Include="..\PolySharp.SourceGenerators\PolySharp.SourceGenerators.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup Label="Package">
 
     <!-- Include the custom .targets file to check the source generator -->
-    <None Include="..\PolySharp.SourceGenerators\PolySharp.targets" PackagePath="buildTransitive\PolySharp.targets" Pack="true" />
-    <None Include="..\PolySharp.SourceGenerators\PolySharp.targets" PackagePath="build\PolySharp.targets" Pack="true" />
+    <None Include="..\PolySharp.SourceGenerators\PolySharp.targets" PackagePath="buildTransitive\" Pack="true" />
+    <None Include="..\PolySharp.SourceGenerators\PolySharp.targets" PackagePath="build\" Pack="true" />
+
+    <!-- Pack the source generator binary -->
+     <None Include="..\PolySharp.SourceGenerators\bin\$(Configuration)\netstandard2.0\PolySharp.SourceGenerators.dll" PackagePath="analyzers\dotnet\cs" Pack="true" />
   </ItemGroup>
 
 </Project>

--- a/src/PolySharp.Package/PolySharp.Package.msbuildproj
+++ b/src/PolySharp.Package/PolySharp.Package.msbuildproj
@@ -12,11 +12,18 @@
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
+  <!-- NuGet package info -->
   <PropertyGroup>
-    <PackageId>PolySharp</PackageId>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>PolySharp</Title>
     <Description>PolySharp provides generated, source-only polyfills for C# language features, to easily use all runtime-agnostic features downlevel</Description>
+    <PackageId>PolySharp</PackageId>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageProjectUrl>https://github.com/Sergio0694/ComputeSharp/</PackageProjectUrl>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageTags>dotnet net netcore netstandard csharp library generator polyfill roslyn</PackageTags>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Related to https://github.com/devlooped/nugetizer/issues/371

### Description

This PR drops the NuGetizer package and just uses vanilla SDK packaging to create the NuGet package.