### PR TITLE
Remove ExcludeFromCodeCoverage in case the type is not public

### DIFF
--- a/src/PolySharp.SourceGenerators/PolyfillsGenerator.Polyfills.cs
+++ b/src/PolySharp.SourceGenerators/PolyfillsGenerator.Polyfills.cs
@@ -140,8 +140,9 @@ partial class PolyfillsGenerator
         {
             SyntaxFixupType fixupType = SyntaxFixupType.None;
 
-            // Strip the [ExcludeFromCodeCoverage] uses if the target framework doesn't have the type
-            if (compilation.GetTypeByMetadataName("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute") is null)
+            // Strip the [ExcludeFromCodeCoverage] uses if the target framework doesn't have the type or cannot access it.
+            // We can't just check whether the type exists, as on .NET Standard 1.3 projects it might exist but be internal.
+            if (!compilation.HasAccessibleTypeWithMetadataName("System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute"))
             {
                 fixupType |= SyntaxFixupType.RemoveExcludeFromCodeCoverageAttributes;
             }


### PR DESCRIPTION
### Closes #<ISSUE_NUMBER>

### Description (optional)

I came across this definition when referencing System.Collections.Immutable in a project that targets .NETstandard 1.3
The attribute is declared internal, so the generated code does not compile.

![image](https://github.com/Sergio0694/PolySharp/assets/5023998/e387d4e6-6257-4324-80d6-bc6a4ae1441c)

In the PR I try to reuse the existing check whether "ExcludeFromCodeCoverage" should be removed, in case no public "ExcludeFromCodeCoverage" is found in the compilation

