### PR TITLE
Update Roslyn version error message

### DIFF
--- a/src/PolySharp.SourceGenerators/PolySharp.targets
+++ b/src/PolySharp.SourceGenerators/PolySharp.targets
@@ -44,7 +44,7 @@
     -->
     <Error Condition ="'$(PolySharpCurrentCompilerVersionIsNotNewEnough)' == 'true'"
            Code="POLYSPCFG0001"
-           Text="The PolySharp source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. PolySharp requires the source generators to run in order to process shaders, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.3 or greater) or .NET SDK version (.NET 6.0.400 SDK or greater)."/>  
+           Text="The PolySharp source generators have been disabled on the current configuration, as they need Roslyn 4.3 in order to work. PolySharp requires the source generators to run in order to generate polyfills, so the library cannot be used without a more up to date IDE (eg. VS 2022 17.3 or greater) or .NET SDK version (.NET 6.0.400 SDK or greater)."/>  
   </Target>
   
   <!-- Remove the analyzer if Roslyn is missing -->


### PR DESCRIPTION
The current message mentions "shaders", which is irrelevant since PolySharp doesn't process any. Seems to be a leftover from copying the target from ComputeSharp.