### PR TITLE
Remove .NET Core 3.1 TFMs

### DIFF
--- a/tests/PolySharp.NuGet/PolySharp.NuGet.csproj
+++ b/tests/PolySharp.NuGet/PolySharp.NuGet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net48;net481;netstandard2.0;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net48;net481;netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
       ..\..\artifacts;

--- a/tests/PolySharp.Tests/LanguageFeatures.cs
+++ b/tests/PolySharp.Tests/LanguageFeatures.cs
@@ -2,7 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
-#if !NETCOREAPP3_1 && !NETSTANDARD2_1
+#if !NETSTANDARD2_1
 using System.Threading.Tasks;
 #endif
 
@@ -170,7 +170,7 @@ internal struct TestHandler
 {
 }
 
-#if !NETCOREAPP3_1 && !NETSTANDARD2_1
+#if !NETSTANDARD2_1
 
 internal struct TaskLikeType
 {

--- a/tests/PolySharp.Tests/PolySharp.Tests.csproj
+++ b/tests/PolySharp.Tests/PolySharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net48;netstandard2.0;netstandard2.1;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net48;netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
 

--- a/tests/PolySharp.TypeForwards.Tests/PolySharp.TypeForwards.Tests.csproj
+++ b/tests/PolySharp.TypeForwards.Tests/PolySharp.TypeForwards.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net48;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net472;net48;net6.0;net7.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PolySharpUsePublicAccessibilityForGeneratedTypes>true</PolySharpUsePublicAccessibilityForGeneratedTypes>
   </PropertyGroup>

--- a/tests/PolySharp.TypeForwards.Tests/TypeForwardTests.cs
+++ b/tests/PolySharp.TypeForwards.Tests/TypeForwardTests.cs
@@ -13,7 +13,7 @@ public class TypeForwardTests
     [TestMethod]
     public void Index_IsForwarded()
     {
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER 
+#if NET6_0_OR_GREATER 
         Assert.AreEqual(typeof(object).Assembly, typeof(Index).Assembly);
         Assert.AreEqual(typeof(Index).Assembly.GetName().Name!, typeof(TypeForwardTests).Assembly.GetType("System.Index")!.Assembly.GetName().Name);
 #else
@@ -24,7 +24,7 @@ public class TypeForwardTests
     [TestMethod]
     public void Range_IsForwarded()
     {
-#if NETCOREAPP3_1 || NET6_0_OR_GREATER 
+#if NET6_0_OR_GREATER 
         Assert.AreEqual(typeof(object).Assembly, typeof(Range).Assembly);
         Assert.AreEqual(typeof(Range).Assembly.GetName().Name!, typeof(TypeForwardTests).Assembly.GetType("System.Range")!.Assembly.GetName().Name);
 #else


### PR DESCRIPTION
### Description

This PR removes .NET Core 3.1 from all TFMs, as it's no longer supported.