### PR TITLE
Exclude RequiresAssemblyFilesAttribute from code coverage

### DIFF
--- a/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute.cs
+++ b/src/PolySharp.SourceGenerators/EmbeddedResources/RuntimeSupported/System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute.cs
@@ -16,6 +16,7 @@ namespace System.Diagnostics.CodeAnalysis
         global::System.AttributeTargets.Method |
         global::System.AttributeTargets.Property,
         Inherited = false, AllowMultiple = false)]
+    [global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     [global::System.Diagnostics.Conditional("MULTI_TARGETING_SUPPORT_ATTRIBUTES")]
     internal sealed class RequiresAssemblyFilesAttribute : global::System.Attribute
     {


### PR DESCRIPTION
### Closes #62

### Description (optional)

Most types were already annotated with `ExcludeFromCodeCoverage` but one type was forgotten.

### Additional context (optional)

[ReportGenerator](https://www.nuget.org/packages/dotnet-reportgenerator-globaltool) complains about missing source code when generating code coverage reports.

> 2023-09-29T18:28:00: File '/project/PolySharp.SourceGenerators/PolySharp.SourceGenerators.PolyfillsGenerator/System.Diagnostics.CodeAnalysis.RequiresAssemblyFilesAttribute.g.cs' does not exist (any more).