### PR TITLE
Add setup-dotnet action

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
     - name: Git checkout
       uses: actions/checkout@v3
+    - name: Set up .NET
+      uses: actions/setup-dotnet@v4
     - name: Build
       run: dotnet build -c ${{matrix.configuration}} /bl
     - name: Upload MSBuild binary log


### PR DESCRIPTION
### Description (optional)

This will install the .NET SDK version specified in `global.json`.

### Additional context (optional)

https://github.com/Sergio0694/PolySharp/pull/108#issuecomment-2475065118 says:

> Waiting for GitHub Actions to update the VM images to include the .NET 9 SDK

You don't have to wait; you can install the SDK as part of each build.