### PR TITLE
Update MSTest to 3.9.1 and use metapackage

### DIFF
--- a/tests/PolySharp.TypeForwards.Tests/PolySharp.TypeForwards.Tests.csproj
+++ b/tests/PolySharp.TypeForwards.Tests/PolySharp.TypeForwards.Tests.csproj
@@ -11,9 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.6.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.6.2" />
+    <PackageReference Include="MSTest" Version="3.10.4" />
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">


### PR DESCRIPTION
### Description (optional)

Dependency update, and using metapackage instead of referencing test framework and test adapter individually.

### API breakdown (for new features)

This section should contain the APIs being implemented.

### Additional context (optional)

Any additional info that might be useful to resolve the issue.
