### PR TITLE
Support always generating polyfills through the new PolySharpAlwaysGeneratePolyfills build variable

### DIFF
--- a/PolySharp.slnx
+++ b/PolySharp.slnx
@@ -10,6 +10,9 @@
     <Project Path="tests/PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests/PolySharp.PolySharpUseTypeAliasForUnmanagedCallersOnlyAttribute.Tests.csproj" />
     <Project Path="tests/PolySharp.Tests/PolySharp.Tests.csproj" />
     <Project Path="tests/PolySharp.TypeForwards.Tests/PolySharp.TypeForwards.Tests.csproj" />
+    <Project Path="tests/PolySharp.AlwaysGeneratePolyfills.Tests/PolySharp.AlwaysGeneratePolyfills.Tests.csproj" />
+    <Project Path="tests/PolySharp.TestLibraryA/PolySharp.TestLibraryA.csproj" />
+    <Project Path="tests/PolySharp.TestLibraryB/PolySharp.TestLibraryB.csproj" />
   </Folder>
   <Folder Name="/_SolutionItems/">
     <File Path=".editorconfig" />

--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ The following properties are available:
 - "PolySharpExcludeGeneratedTypes": excludes specific types from generation (';' or ',' separated type names).
 - "PolySharpIncludeGeneratedTypes": only includes specific types for generation (';' or ',' separated type names).
 - "PolySharpExcludeTypeForwardedToDeclarations": never generates any `[TypeForwardedTo]` declarations.
+- "PolySharpAlwaysGeneratePolyfills": generates the polyfills, even when they are available from the referenced projects. Addresses the issue https://github.com/Sergio0694/PolySharp/issues/50

--- a/src/PolySharp.SourceGenerators/Constants/PolySharpMSBuildProperties.cs
+++ b/src/PolySharp.SourceGenerators/Constants/PolySharpMSBuildProperties.cs
@@ -26,6 +26,11 @@ internal static class PolySharpMSBuildProperties
     public const string ExcludeGeneratedTypes = "PolySharpExcludeGeneratedTypes";
 
     /// <summary>
+    /// The MSBuild property for <see cref="Models.GenerationOptions.AlwaysGeneratePolyfills"/>.
+    /// </summary>
+    public const string AlwaysGeneratePolyfills = "PolySharpAlwaysGeneratePolyfills";
+
+    /// <summary>
     /// The MSBuild property for <see cref="Models.GenerationOptions.IncludeGeneratedTypes"/>.
     /// </summary>
     public const string IncludeGeneratedTypes = "PolySharpIncludeGeneratedTypes";

--- a/src/PolySharp.SourceGenerators/Diagnostics/Analyzers/InvalidPolySharpMSBuildOptionAnalyzer.Execute.cs
+++ b/src/PolySharp.SourceGenerators/Diagnostics/Analyzers/InvalidPolySharpMSBuildOptionAnalyzer.Execute.cs
@@ -59,6 +59,14 @@ partial class InvalidPolySharpMSBuildOptionAnalyzer
 
         token.ThrowIfCancellationRequested();
 
+        // And for "AlwaysGeneratePolyfills" as well
+        if (!options.IsValidMSBuildProperty(PolySharpMSBuildProperties.AlwaysGeneratePolyfills, out string? alwaysGeneratePolyfills))
+        {
+            builder.Add(InvalidBoolMSBuildProperty, alwaysGeneratePolyfills, PolySharpMSBuildProperties.AlwaysGeneratePolyfills);
+        }
+
+        token.ThrowIfCancellationRequested();
+
         ImmutableArray<string> excludeGeneratedTypes = options.GetStringArrayMSBuildProperty(PolySharpMSBuildProperties.ExcludeGeneratedTypes);
 
         // Validate the fully qualified type names for "ExcludeGeneratedTypes"

--- a/src/PolySharp.SourceGenerators/Models/GenerationOptions.cs
+++ b/src/PolySharp.SourceGenerators/Models/GenerationOptions.cs
@@ -9,6 +9,7 @@ namespace PolySharp.SourceGenerators.Models;
 /// <param name="IncludeRuntimeSupportedAttributes">Whether to also generated dummy runtime supported attributes.</param>
 /// <param name="UseInteropServices2NamespaceForUnmanagedCallersOnlyAttribute">Whether to move the <c>[UnmanagedCallersOnly]</c> type to a dummy <c>InteropServices2</c> namespace.</param>
 /// <param name="ExcludeTypeForwardedToDeclarations">Whether to never generate any <c>[TypeForwardedTo]</c> declarations automatically.</param>
+/// <param name="AlwaysGeneratePolyfills">Whether to generate polyfills even if they are available through a referenced project.</param>
 /// <param name="ExcludeGeneratedTypes">The collection of fully qualified type names of types to exclude from generation.</param>
 /// <param name="IncludeGeneratedTypes">The collection of fully qualified type names of types to include in the generation.</param>
 internal sealed record GenerationOptions(
@@ -16,5 +17,6 @@ internal sealed record GenerationOptions(
     bool IncludeRuntimeSupportedAttributes,
     bool UseInteropServices2NamespaceForUnmanagedCallersOnlyAttribute,
     bool ExcludeTypeForwardedToDeclarations,
+    bool AlwaysGeneratePolyfills,
     EquatableArray<string> ExcludeGeneratedTypes,
     EquatableArray<string> IncludeGeneratedTypes);

--- a/src/PolySharp.SourceGenerators/PolySharp.targets
+++ b/src/PolySharp.SourceGenerators/PolySharp.targets
@@ -114,6 +114,7 @@
       <CompilerVisibleProperty Include="PolySharpExcludeGeneratedTypes"/>
       <CompilerVisibleProperty Include="PolySharpIncludeGeneratedTypes"/>
       <CompilerVisibleProperty Include="PolySharpExcludeTypeForwardedToDeclarations"/>
+      <CompilerVisibleProperty Include="PolySharpAlwaysGeneratePolyfills"/>
     </ItemGroup>
 
     <!-- Adds necessary fixups for multiline properties (replaces ';' characters with ',' and strip new lines) -->

--- a/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
+++ b/src/PolySharp.SourceGenerators/PolyfillsGenerator.cs
@@ -21,7 +21,8 @@ public sealed partial class PolyfillsGenerator : IIncrementalGenerator
         // Get the sequence of all available types that could be generated
         IncrementalValuesProvider<AvailableType> availableTypes =
             context.CompilationProvider
-            .SelectMany(GetAvailableTypes);
+            .Combine(generationOptions)
+            .SelectMany(static (pair, token) => GetAvailableTypes(pair.Left, pair.Right, token));
 
         // Gather the sequence of all types to generate after filtering
         IncrementalValuesProvider<GeneratedType> generatedTypes =

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,8 @@
+﻿<Project>
+  <PropertyGroup>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <IsPackable>false</IsPackable>
+    <UpstreamDirectoryBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)\..\'))</UpstreamDirectoryBuildProps>
+  </PropertyGroup>
+  <Import Project="$(UpstreamDirectoryBuildProps)" Condition="$(UpstreamDirectoryBuildProps) != ''" />
+</Project>

--- a/tests/PolySharp.AlwaysGeneratePolyfills.Tests/AlwaysGeneratePolyfillsTests.cs
+++ b/tests/PolySharp.AlwaysGeneratePolyfills.Tests/AlwaysGeneratePolyfillsTests.cs
@@ -1,0 +1,13 @@
+using PolySharp.TestLibraryA;
+using PolySharp.TestLibraryB;
+using System;
+
+namespace PolySharp.AlwaysGeneratePolyfills.Tests;
+
+public class ConsumerClass
+{
+    public Type TestLibraryA => typeof(LibraryAClass);
+    public Type TestLibraryB => typeof(LibraryBClass);
+    public required string RequiredValue { get; init; }
+    public string? OptionalValue { get; init; }
+}

--- a/tests/PolySharp.AlwaysGeneratePolyfills.Tests/PolySharp.AlwaysGeneratePolyfills.Tests.csproj
+++ b/tests/PolySharp.AlwaysGeneratePolyfills.Tests/PolySharp.AlwaysGeneratePolyfills.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <PolySharpAlwaysGeneratePolyfills>true</PolySharpAlwaysGeneratePolyfills>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PolySharp.TestLibraryA\PolySharp.TestLibraryA.csproj" />
+    <ProjectReference Include="..\PolySharp.TestLibraryB\PolySharp.TestLibraryB.csproj" />
+    <ProjectReference Include="..\..\src\PolySharp.SourceGenerators\PolySharp.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+  </ItemGroup>
+
+  <!-- Import the PolySharp targets manually since we're using ProjectReference instead of PackageReference -->
+  <Import Project="..\..\src\PolySharp.SourceGenerators\PolySharp.targets" />
+
+</Project>

--- a/tests/PolySharp.TestLibraryA/LibraryAClass.cs
+++ b/tests/PolySharp.TestLibraryA/LibraryAClass.cs
@@ -1,0 +1,6 @@
+namespace PolySharp.TestLibraryA;
+
+internal class LibraryAClass
+{
+    public required string Name { get; init; }
+}

--- a/tests/PolySharp.TestLibraryA/PolySharp.TestLibraryA.csproj
+++ b/tests/PolySharp.TestLibraryA/PolySharp.TestLibraryA.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="PolySharp.AlwaysGeneratePolyfills.Tests" />
+    <ProjectReference Include="..\..\src\PolySharp.SourceGenerators\PolySharp.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+  </ItemGroup>
+
+</Project>

--- a/tests/PolySharp.TestLibraryB/LibraryBClass.cs
+++ b/tests/PolySharp.TestLibraryB/LibraryBClass.cs
@@ -1,0 +1,6 @@
+namespace PolySharp.TestLibraryB;
+
+internal class LibraryBClass
+{
+    public required string Title { get; init; }
+}

--- a/tests/PolySharp.TestLibraryB/PolySharp.TestLibraryB.csproj
+++ b/tests/PolySharp.TestLibraryB/PolySharp.TestLibraryB.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="PolySharp.AlwaysGeneratePolyfills.Tests" />
+    <ProjectReference Include="..\..\src\PolySharp.SourceGenerators\PolySharp.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="contentfiles;build" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Closes #50

### Description

Introduces the `PolySharpAlwaysGeneratePolyfills` build variable to always generate polyfills, even if already available transitively.
